### PR TITLE
feat(airbnb): full marketplace example spec

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -191,6 +191,11 @@ actor Booking(id: Id) {
 The subscriber doesn't know which provider fired the event; the contract is
 the event shape on the external actor.
 
+Webhook routes are **codegen-derived** — when an external actor declares
+`emits`, the codegen produces the inbound HTTP handler that validates the
+provider's signature and dispatches to subscribers. The spec does not
+declare controller routes for webhooks.
+
 ### Single provider, swappable
 
 When you'll only ever use one provider but want to swap by editing one
@@ -288,6 +293,35 @@ flow Name(arg: Type, ..., now: Timestamp, key: Key) -> Result<Ok, Err> {
 - `commit <value>` ends the flow with a success value. Bare `commit` returns
   unit.
 
+### Scheduled flows
+
+A `schedule` declaration runs a flow periodically or at a specific time. It
+lives at the top level of a feature, alongside `flow`. Two forms:
+
+**Recurring** — run every `<duration>`, optionally for each instance
+matching a predicate:
+
+```candy
+schedule ChargeCycle(now)
+  every 30d
+  for any subscription in Subscription where status == Active
+```
+
+The flow receives the matched instance (via the loop variable) and `now` as
+inputs. Predicates use the same `where` syntax as derive/lookup.
+
+**One-shot** — run once at a specific timestamp:
+
+```candy
+schedule SendReminder(user.id, now)
+  at user.created after 24h
+  for any user in User where verified == false
+```
+
+Schedules emit `ScheduleFired` events for observability. Failures rescheduling
+follow the flow's own `rescue` semantics — there is no implicit retry at the
+schedule layer.
+
 ---
 
 ## controller
@@ -358,6 +392,7 @@ prose {
 
   uses:
     feature  Wallet   for Topup, Debit
+    feature  Auth     for event UserSignedUp
     external Payments for Charge, Refund
 
   policies: [BearerAuth, RateLimit]
@@ -369,8 +404,12 @@ Fields:
 - **`intent:`** — what + why. Conventionally always present.
 - **`exports:`** — public API. Anything not exported is private; codegen
   refuses cross-feature references to private items.
-- **`uses:`** — cross-feature and external dependencies, with the specific
-  operations each consumer relies on. Makes the dependency graph grep-able.
+- **`uses:`** — cross-feature and external dependencies. Three forms:
+  - `feature X for OpName` — calls a flow or actor message exported by feature X.
+  - `feature X for event EventName` — subscribes to an event emitted by feature X.
+  - `external X for OpName` — calls or subscribes to an external actor.
+
+  Makes the dependency graph grep-able.
 - **`policies:`** — feature-scoped policies that apply to every controller
   and flow inside the feature.
 
@@ -543,7 +582,9 @@ field)` destructures variant payload.
 
 **Reserved primitives.** Built-in functions: `generate()` (new id),
 `hash(value)`, `verify(value, hash)`, `sum(list)`, `length(list)`, `last(list)`.
-Lists support `where <predicate>`, `+` (append), `[id]` (index by id field).
+`sum`, `length`, `last` work on lists of any numeric primitive, including
+branded `int`/`decimal` types like `Money`. Lists support `where <predicate>`,
+`+` (append), `[id]` (index by id field).
 
 **Comments.** `// line comment`. No block comments — paragraphs go in
 `intent:` blocks.

--- a/examples/airbnb/README.md
+++ b/examples/airbnb/README.md
@@ -1,0 +1,272 @@
+# airbnb — full marketplace example
+
+A short-stay rental marketplace: hosts list properties, guests book stays
+on date ranges, coupons reduce price, payments settle the booking, and
+the platform takes a cut. This is the largest example in the repo — a
+multi-feature project with cross-feature event subscriptions, an external
+payment provider with multiple providers configured, and a canonical
+multi-actor saga (`PlaceBooking`) that demonstrates compensation across
+network boundaries.
+
+Wallet is *not* in airbnb — it's its own standalone example. Booking
+settles directly through the external `Payments` actor (charge guest,
+transfer to host).
+
+## What this exercises
+
+- **`prose` block** in every feature — intent, exports, uses, policies (GRAMMAR.md "prose").
+- **Single-file features** (one `.candy` per feature, flat layout) per the project decision.
+- **Cross-feature `uses:`** including the `feature X for event Y` form (subscribers).
+- **Multi-actor saga** with `compensate` across network boundaries (booking).
+- **External actor with multiple providers** (`Payments` with `providers: [Stripe, Polar, Lemon]`) and `Actor[Tag]` selection (GRAMMAR.md "external actor", "Multiple providers").
+- **Webhook subscriptions** (`subscribe ChargeSucceeded -> ConfirmBooking`).
+- **Policy attachment** at type-, actor-, flow-, controller-, and feature-scope (GRAMMAR.md "Policy attachment").
+- **Idempotency keys** on every replayable flow.
+- **Branded `Money`** and minor-units arithmetic; conservation invariants.
+- **Role-gated controllers** (admin endpoints for coupon management, host endpoints for listings).
+
+## Project structure
+
+```
+examples/airbnb/
+  candy.toml          ← manifest
+  preferences.candy   ← per-target library bindings (incl. payment providers)
+  README.md           ← this file (project scope + symbol contract)
+
+  types.candy         ← shared types (#2)
+  events.candy        ← cross-feature events (#3)
+  invariants.candy    ← system-wide truths (#4)
+  externals.candy     ← Payments external actor (#20)
+
+  auth.candy          ← User, Session, Signup/Login/Logout (#5)
+  listings.candy      ← Listing, Calendar, CRUD + HoldDates/ReleaseDates (#7)
+  coupons.candy       ← Coupon, Validate/Redeem/Restore, admin CRUD (#9)
+  booking.candy       ← Booking, PlaceBooking saga, CancelBooking (#8)
+```
+
+Conformance evals live at `evals/airbnb/{auth,listings,booking,coupons}.hurl` (#10, #11).
+
+## Symbol contract
+
+This section is the source of truth for cross-feature names. Every spec
+file in this project must use these exact identifiers and shapes.
+
+### Shared types (defined in `types.candy`)
+
+```
+type Id          opaque  { max: 64 }
+type Timestamp   instant { tz: utc }
+type Date        instant { tz: utc, precision: day }
+type DateRange   { from: Date, to: Date }
+type Email       string  { max: 320, format: rfc5322 }
+type Password    string  { policies: [PasswordStrength] }
+type PasswordHash opaque
+type Token       opaque  { max: 256 }
+type Key         opaque  { max: 128 }
+type Money       int     { unit: minor, currency: USD, round: nearest }
+type CouponCode  string  { max: 32 }
+
+type PaymentMethod opaque { max: 256 }
+type ChargeId      opaque { max: 128 }
+type RefundId      opaque { max: 128 }
+type TransferId    opaque { max: 128 }
+
+enum Role           { Guest, Host, Admin }
+enum BookingStatus  { Pending, Confirmed, Cancelled, Completed }
+enum ListingStatus  { Draft, Listed, Hidden }
+enum CouponKind     { Percent, FixedAmount }
+```
+
+### Shared events (defined in `events.candy`)
+
+All events use `delivery: eager` unless noted; ordering is `by` the most
+relevant identifier so subscribers can dedupe.
+
+```
+event UserSignedUp    { payload: { user: Id, email: Email, at: Timestamp }, delivery: eager }
+event UserVerified    { payload: { user: Id, at: Timestamp },               delivery: eager }
+event UserLoggedIn    { payload: { user: Id, at: Timestamp },               delivery: eager, order: by user }
+event SessionRevoked  { payload: { token: Token, user: Id, at: Timestamp }, delivery: eager }
+
+event ListingCreated  { payload: { listing: Id, host: Id, at: Timestamp }, delivery: eager, order: by listing }
+event ListingUpdated  { payload: { listing: Id, at: Timestamp },           delivery: eager, order: by listing }
+event ListingHidden   { payload: { listing: Id, at: Timestamp },           delivery: eager, order: by listing }
+
+event CouponCreated   { payload: { coupon: Id, code: CouponCode, at: Timestamp }, delivery: eager }
+event CouponRedeemed  { payload: { coupon: Id, user: Id, booking: Id, at: Timestamp }, delivery: eager, order: by coupon }
+event CouponRestored  { payload: { coupon: Id, booking: Id, at: Timestamp }, delivery: eager, order: by coupon }
+
+event BookingPlaced     { payload: { booking: Id, listing: Id, guest: Id, dates: DateRange, total: Money, at: Timestamp }, delivery: eager, order: by booking }
+event BookingConfirmed  { payload: { booking: Id, charge: ChargeId, at: Timestamp }, delivery: eager, order: by booking }
+event BookingCancelled  { payload: { booking: Id, reason: string, at: Timestamp }, delivery: eager, order: by booking }
+```
+
+### System-wide invariants (defined in `invariants.candy`)
+
+```
+invariant SlotIntegrity:
+  "no two Confirmed bookings share a (listing, date) tuple"
+
+invariant CouponSingleUse:
+  "a coupon is redeemed at most once per (coupon, user) pair"
+
+invariant BookingHostMatchesListing:
+  "for any Booking b: b.host == Listing(b.listing).host"
+
+invariant SessionUserConsistency:
+  "for any active Session s: User(s.user) exists and is verified"
+```
+
+### External actor (defined in `externals.candy`)
+
+```candy
+external actor Payments {
+  providers: [Stripe, Polar, Lemon]
+
+  config Stripe: api_key: secret "STRIPE_KEY"
+                 webhook_secret: secret "STRIPE_WEBHOOK_SECRET"
+  config Polar:  api_key: secret "POLAR_KEY"
+                 webhook_secret: secret "POLAR_WEBHOOK_SECRET"
+  config Lemon:  api_key: secret "LEMONSQUEEZY_KEY"
+                 webhook_secret: secret "LEMONSQUEEZY_WEBHOOK_SECRET"
+
+  accepts Charge(amount: Money, source: PaymentMethod, key: Key)
+    -> Result<ChargeId, PaymentDeclined | NetworkError | RateLimited>
+
+  accepts Refund(charge: ChargeId, amount: Money?, key: Key)
+    -> Result<RefundId, RefundError | NetworkError>
+
+  accepts Transfer(to: Id, amount: Money, key: Key)
+    -> Result<TransferId, TransferFailed | NetworkError>
+
+  emits ChargeSucceeded { charge: ChargeId, booking: Id, at: Timestamp }
+  emits ChargeFailed    { charge: ChargeId, booking: Id, reason: string, at: Timestamp }
+  emits RefundProcessed { refund: RefundId, charge: ChargeId, at: Timestamp }
+}
+```
+
+The `booking` field on `ChargeSucceeded`/`ChargeFailed` is the booking
+that initiated the charge — passed via Stripe metadata / Polar custom
+fields / LemonSqueezy custom data and surfaced uniformly by codegen.
+
+### Per-feature exports
+
+Every feature's `prose` block declares exactly these exports. Other
+features `uses:` them by these names.
+
+| Feature   | Exports                                                                            |
+|-----------|------------------------------------------------------------------------------------|
+| auth      | `actor User, Session`; `flow Signup, Login, Logout, Verify`; `event UserSignedUp, UserVerified, UserLoggedIn, SessionRevoked` |
+| listings  | `actor Listing, Calendar`; `flow CreateListing, UpdateListing, ListListings, HoldDates, ReleaseDates`; `event ListingCreated, ListingUpdated, ListingHidden` |
+| coupons   | `actor Coupon`; `flow CreateCoupon, DeleteCoupon, ValidateCoupon, RedeemCoupon, RestoreCoupon`; `event CouponCreated, CouponRedeemed, CouponRestored` |
+| booking   | `actor Booking`; `flow PlaceBooking, CancelBooking, CompleteBooking`; `event BookingPlaced, BookingConfirmed, BookingCancelled` |
+
+### Cross-feature dependency graph
+
+```
+booking  uses  feature listings  for HoldDates, ReleaseDates
+              feature coupons   for ValidateCoupon, RedeemCoupon, RestoreCoupon
+              external Payments for Charge, Refund, Transfer
+              external Payments for event ChargeSucceeded, ChargeFailed
+
+listings uses feature auth      for event UserSignedUp     (host upgrade hook — optional)
+
+coupons  uses (nothing — leaf feature)
+
+auth     uses (nothing — leaf feature)
+```
+
+### Policies referenced across the project
+
+| Policy                      | Defined in   | Attaches to                              |
+|-----------------------------|--------------|------------------------------------------|
+| `PasswordStrength`          | auth         | type `Password`                          |
+| `BearerAuth`                | auth         | controller (feature-scope on auth)       |
+| `RoleGated`                 | auth         | controller routes (per-route)            |
+| `AdminGated`                | coupons      | controller routes (admin endpoints)      |
+| `CouponEligibility`         | coupons      | flow `RedeemCoupon`                      |
+| `CancellationPolicy`        | booking      | flow `CancelBooking`                     |
+| `BookingAtomicity`          | booking      | flow `PlaceBooking`                      |
+
+## Per-feature scope
+
+### `auth` — User, Session, signup/login/logout (#5)
+
+Adapted from `examples/auth/auth.candy`. Adds:
+- `prose` block with intent/exports/policies.
+- `User.role: Role` field (Guest by default; promoted by admin or self-service host upgrade).
+- Role-gated controller routes via `RoleGated` policy attached per-route. Admin-only routes for user moderation; host-only checks for listing endpoints (in `listings`).
+- All flows accept `key: Key` for idempotency.
+- `Session` actor with token, expires, revoked. `Validate(now)` returns user id + role.
+
+### `listings` — Listing, Calendar, hold-and-release (#7)
+
+- `Listing(id)` — host id, status, title, location prose, base price (Money), max guests, calendar (derived from Calendar actor).
+- `Calendar(listing)` — sparse map of Date → BookingId. State is the held-set.
+- `HoldDates(listing, dates: DateRange, booking: Id, key: Key)` — exported for booking saga; rejects `DatesUnavailable` on overlap. Compensation: `ReleaseDates`.
+- `ReleaseDates(listing, dates: DateRange, key: Key)` — idempotent unhold.
+- `CreateListing` / `UpdateListing` host-gated; `ListListings(filter)` public.
+- Emits `ListingCreated`, `ListingUpdated`, `ListingHidden`.
+
+### `coupons` — Coupon, eligibility, redeem/restore (#9)
+
+- `Coupon(code: CouponCode)` — kind (Percent | FixedAmount), value, max uses, expires, redemptions journal.
+- `CouponEligibility` policy attached at flow-scope on `RedeemCoupon` — prose-heavy with `examples:` covering: not-found, expired, exhausted, already-redeemed-by-user, ok.
+- `ValidateCoupon(code, user, now)` — pure check, no state change.
+- `RedeemCoupon(code, user, booking, now, key)` — appends to redemptions, emits `CouponRedeemed`. Compensation: `RestoreCoupon`.
+- `RestoreCoupon(coupon, booking, key)` — idempotent unredeem on saga rollback.
+- Admin-only `CreateCoupon`/`DeleteCoupon`.
+- Emits `CouponCreated`, `CouponRedeemed`, `CouponRestored`.
+
+### `booking` — Booking saga, compensate, payments (#8)
+
+- `Booking(id)` — listing, guest, host, dates, status, total, charge?, coupon?
+- `PlaceBooking(listing, guest, dates, source: PaymentMethod, code: CouponCode?, now, key)` — the canonical saga:
+  1. `step held = ask Listing(listing).HoldDates(dates, self.id, key)` rescue reject `DatesUnavailable`.
+  2. `step discount = if code? then ask coupons.ValidateCoupon(code, guest, now) else 0`.
+  3. `step total = listing.price * dates.nights - discount`.
+  4. `step paid = ask Payments[Stripe].Charge(total, source, key)` rescue compensate held; reject `PaymentDeclined`. (Caller can swap `[Stripe]` → `[Polar]` or `[Lemon]`; the canonical example pins Stripe; a fallback variant `PlaceBookingWithFallback` is included to demonstrate the rescue chain.)
+  5. `step redeemed = if code? then ask coupons.RedeemCoupon(code, guest, self.id, now, key) else unit` rescue compensate paid (refund), held; reject `CouponConflict`.
+  6. `commit Booking { status: Pending, charge: paid, total, ... }`; `emit BookingPlaced`.
+  7. `subscribe ChargeSucceeded(self.charge) -> ConfirmBooking` (move to Confirmed).
+- `CancelBooking(booking, reason, now, key)` — guarded by `CancellationPolicy` (refund eligibility window), then refund, restore coupon, release dates, set Cancelled.
+- `BookingAtomicity` flow-scope policy: ensures all-or-nothing across the saga.
+- Emits `BookingPlaced`, `BookingConfirmed`, `BookingCancelled`.
+
+### `externals` — Payments multi-provider (#20)
+
+See "External actor" in the symbol contract above. The example pins
+`Payments[Stripe]` as the default provider in the saga; preferences.candy
+binds the per-target SDK for each of `stripe`, `polar`, `lemon`.
+
+## Codegen targets
+
+All four targets supported (Go/chi, Rust/axum, TypeScript/hono,
+Python/fastapi). Per-target idiom highlights:
+
+- **Go (chi)** — `sqlc` for queries, `chi` for routing, `stripe-go` for Payments[Stripe].
+- **Rust (axum)** — `sqlx` for queries, axum tower layers for policies, `async-stripe` for Payments[Stripe].
+- **TypeScript (hono)** — `drizzle` for ORM, hono middleware for policies, `stripe-node` for Payments[Stripe].
+- **Python (fastapi)** — `sqlalchemy` for ORM, FastAPI dependencies for policies, `stripe-python` for Payments[Stripe].
+
+## Conformance
+
+Per-feature `.hurl` files under `evals/airbnb/`:
+
+- `auth.hurl` — full coverage including role-gated checks (#10).
+- `listings.hurl`, `booking.hurl`, `coupons.hurl` — TODO stubs to be filled (#11).
+
+## Issue tracking
+
+| Issue | File                  | Status      |
+|-------|-----------------------|-------------|
+| #2    | `types.candy`         | Implementing |
+| #3    | `events.candy`        | Implementing |
+| #4    | `invariants.candy`    | Implementing |
+| #20   | `externals.candy`     | Implementing |
+| #5    | `auth.candy`          | Implementing |
+| #7    | `listings.candy`      | Implementing |
+| #9    | `coupons.candy`       | Implementing |
+| #8    | `booking.candy`       | Implementing |
+| #10   | `evals/airbnb/auth.hurl` | Pending |
+| #11   | other `evals/airbnb/*.hurl` | Pending |

--- a/examples/airbnb/auth.candy
+++ b/examples/airbnb/auth.candy
@@ -1,0 +1,279 @@
+// auth.candy — User, Session, signup/login/logout.
+
+prose {
+  intent: """
+    Authentication for the Airbnb marketplace. Handles account creation,
+    credential verification, and session lifecycle. Users start as Guests
+    and may self-upgrade to Host or be promoted to Admin by an admin.
+
+    Every controller route in this feature is covered by BearerAuth at
+    feature scope. Signup and Login override that with auth: none. Routes
+    that require a minimum role layer RoleGated on top.
+  """
+
+  exports:
+    actor User, Session
+    flow  Signup, Login, Logout, Verify
+    event UserSignedUp, UserVerified, UserLoggedIn, SessionRevoked
+
+  policies: [BearerAuth]
+}
+
+// Password is feature-local. Shared types (Id, Timestamp, Email, PasswordHash,
+// Token, Key, Role) live in types.candy and are not redeclared.
+
+type Password string {
+  intent: "Plaintext at rest is forbidden — only PasswordHash persists."
+  policies: [PasswordStrength]
+}
+
+actor User(id: Id) {
+  state {
+    email:    Email
+    hash:     PasswordHash
+    role:     Role     = Guest
+    verified: bool     = false
+    created:  Timestamp
+  }
+
+  invariant "email is unique across all User instances"
+
+  accepts Verify() -> Result<unit, AlreadyVerified> {
+    intent: "Mark the user's email as verified. Idempotent guard via AlreadyVerified."
+    require: verified == false  rescue reject AlreadyVerified
+    effect: verified = true
+    emit UserVerified { user: self.id, at: now }
+    commit
+  }
+
+  accepts UpgradeToHost() -> Result<unit, AlreadyHost> {
+    intent: "Self-service promotion from Guest to Host. Rejects if already Host or Admin."
+    require: role == Guest  rescue reject AlreadyHost
+    effect: role = Host
+    commit
+  }
+
+  accepts Promote(to: Role) -> Result<unit, InvalidPromotion> {
+    intent: "Admin-driven role change. Rejects Admin → Guest demotions."
+    require: not (role == Admin and to == Guest)  rescue reject InvalidPromotion
+    effect: role = to
+    commit
+  }
+}
+
+actor Session(token: Token) {
+  state {
+    user:    Id
+    role:    Role
+    issued:  Timestamp
+    expires: Timestamp = now after 7d
+    revoked: bool      = false
+  }
+
+  invariant "expires > issued"
+
+  accepts Validate(now: Timestamp) -> Result<{ user: Id, role: Role }, SessionInvalid> {
+    intent: "Return user id and role if the session is live; reject otherwise."
+    require: revoked == false  rescue reject SessionInvalid
+    require: now < expires     rescue reject SessionInvalid
+    commit { user: self.user, role: self.role }
+  }
+
+  accepts Revoke() -> unit {
+    intent: "Mark the session as revoked. Idempotent — re-revoking is a no-op."
+    effect: revoked = true
+    emit SessionRevoked { token: self.token, user: self.user, at: now }
+    commit
+  }
+}
+
+// ─── Policies ─────────────────────────────────────────────────────────────────
+
+policy PasswordStrength {
+  intent: """
+    A password is acceptable when:
+      - length >= 12
+      - contains at least one letter and at least one digit
+      - is not in the common-password blocklist
+
+    Hashing uses argon2id with parameters from deployment secrets.
+    Plaintext passwords never persist; only PasswordHash is stored.
+  """
+  examples:
+    - given: "short1"
+      then:  err(TooShort)
+    - given: "alllowercase"
+      then:  err(MissingDigit)
+    - given: "password123"
+      then:  err(InBlocklist)
+    - given: "correct horse battery staple 9"
+      then:  ok
+}
+
+policy BearerAuth {
+  intent: """
+    Validates the Authorization: Bearer <token> header on every request.
+    Calls Session(token).Validate(now) and binds the returned user id and
+    role for downstream RoleGated checks. Signup and Login override this
+    at route scope with auth: none because callers have no session yet.
+
+    On missing or invalid token the request is rejected with 401.
+    On expired or revoked session the request is rejected with 401.
+  """
+  examples:
+    - given: "valid unexpired token for user with role Host"
+      then:  ok({ user: <id>, role: Host })
+    - given: "expired token"
+      then:  err(SessionInvalid)
+    - given: "missing Authorization header"
+      then:  err(Unauthenticated)
+}
+
+policy RoleGated {
+  intent: """
+    Compares the session-bound role against the required minimum. Roles
+    rank Guest < Host < Admin. A caller whose role is below the required
+    level receives 403 Forbidden; an equal or higher role proceeds.
+
+    The required role is a parameter supplied at the attachment site.
+  """
+  examples:
+    - given: "caller role Guest, required Host"
+      then:  err(InsufficientRole)
+    - given: "caller role Host, required Host"
+      then:  ok
+    - given: "caller role Admin, required Admin"
+      then:  ok
+    - given: "caller role Guest, required Admin"
+      then:  err(InsufficientRole)
+}
+
+// ─── Flows ────────────────────────────────────────────────────────────────────
+
+flow Signup(email: Email, password: Password, now: Timestamp, key: Key)
+  -> Result<{ user: Id, token: Token }, WeakPassword | EmailTaken>
+{
+  intent: """
+    Create a new Guest account, hash the password, and issue an initial
+    session. Idempotent on key — replaying returns the same ids without
+    creating duplicate records or re-emitting events.
+  """
+
+  step strength = PasswordStrength(password)
+                  rescue reject WeakPassword(reason)
+
+  step taken    = if any user in User where user.email == email
+                  then reject EmailTaken
+
+  step user     = ask User.create({
+                    id:      generate(),
+                    email,
+                    hash:    hash(password),
+                    role:    Guest,
+                    created: now,
+                  })
+
+  step session  = ask Session.create({
+                    token:   generate(),
+                    user:    user.id,
+                    role:    Guest,
+                    issued:  now,
+                    expires: now after 7d,
+                  })
+
+  emit UserSignedUp { user: user.id, email, at: now }
+  commit { user: user.id, token: session.token }
+}
+
+flow Login(email: Email, password: Password, now: Timestamp, key: Key)
+  -> Result<{ user: Id, role: Role, token: Token }, InvalidCredentials>
+{
+  intent: """
+    Authenticate by email and password. On success, issue a new session
+    carrying the user's current role. Errors are opaque — never reveal
+    whether email or password was the wrong side.
+  """
+
+  step user    = ask User.findBy(email)                       rescue reject InvalidCredentials
+  step ok      = if not verify(password, user.hash) then reject InvalidCredentials
+  step session = ask Session.create({
+                   token:   generate(),
+                   user:    user.id,
+                   role:    user.role,
+                   issued:  now,
+                   expires: now after 7d,
+                 })
+
+  emit UserLoggedIn { user: user.id, at: now }
+  commit { user: user.id, role: user.role, token: session.token }
+}
+
+flow Logout(token: Token, now: Timestamp, key: Key) -> unit {
+  intent: "Revoke the session for the given bearer token. Idempotent."
+  step _ = ask Session(token).Revoke()
+  commit
+}
+
+flow Verify(user: Id, now: Timestamp, key: Key)
+  -> Result<unit, AlreadyVerified | UserNotFound>
+{
+  intent: "Admin-triggered verification. Email-confirmation loop omitted for brevity."
+  step u = ask User.findBy(id: user)  rescue reject UserNotFound
+  step _ = ask User(user).Verify()    rescue reject AlreadyVerified
+  commit
+}
+
+// ─── Controller ───────────────────────────────────────────────────────────────
+
+controller Auth {
+  POST /signup -> Signup(email, password, now, idempotency_key) {
+    auth: none
+    body: { email: Email, password: Password, idempotency_key: Key }
+    map:
+      ok(result)               -> 201 { user_id: result.user, token: result.token }
+      err(WeakPassword reason) -> 422 { error: "weak_password", reason }
+      err(EmailTaken)          -> 409 { error: "email_taken" }
+  }
+
+  POST /login -> Login(email, password, now, idempotency_key) {
+    auth: none
+    body: { email: Email, password: Password, idempotency_key: Key }
+    map:
+      ok(result)              -> 200 { user_id: result.user, role: result.role, token: result.token }
+      err(InvalidCredentials) -> 401 { error: "invalid_credentials" }
+  }
+
+  POST /logout -> Logout(bearer, now, idempotency_key) {
+    auth: bearer
+    body: { idempotency_key: Key }
+    map:
+      ok(_) -> 204
+  }
+
+  POST /me/upgrade-to-host -> User(self).UpgradeToHost() {
+    auth: bearer
+    policies: [RoleGated(Guest)]
+    map:
+      ok(_)           -> 200 { role: "host" }
+      err(AlreadyHost) -> 409 { error: "already_host" }
+  }
+
+  POST /admin/users/:id/promote -> User(id).Promote(role) {
+    auth: bearer
+    policies: [RoleGated(Admin)]
+    body: { role: Role }
+    map:
+      ok(_)                  -> 200 { promoted: true }
+      err(InvalidPromotion)  -> 422 { error: "invalid_promotion" }
+  }
+
+  POST /admin/users/:id/verify -> Verify(id, now, idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Admin)]
+    body: { idempotency_key: Key }
+    map:
+      ok(_)                -> 200 { verified: true }
+      err(AlreadyVerified) -> 409 { error: "already_verified" }
+      err(UserNotFound)    -> 404 { error: "user_not_found" }
+  }
+}

--- a/examples/airbnb/booking.candy
+++ b/examples/airbnb/booking.candy
@@ -1,0 +1,635 @@
+// booking.candy — the multi-actor booking saga at the heart of the marketplace.
+
+prose {
+  intent: """
+    A Booking is the binding agreement between a guest and a host for a specific
+    listing over a specific date range at an agreed total price. It is the central
+    entity in the marketplace: it references a listing, carries the guest and host
+    identities, the reserved dates, the total charge, any applied coupon discount,
+    and the lifecycle status from Pending through Confirmed, Cancelled, and
+    Completed.
+
+    PlaceBooking is a saga because it touches multiple owned actors and one external
+    network boundary in a single logical operation. It must: (1) hold the listing's
+    calendar dates so no other booking can claim them, (2) validate and redeem a
+    coupon if the guest provided one, (3) charge the guest's payment method via the
+    Payments external actor, and (4) create the Booking record itself. Any of these
+    steps can fail — the listing may be unavailable, the coupon may be expired, the
+    card may decline. A saga with named steps allows each failure to compensate the
+    prior successful steps, leaving the system in a clean state with no dangling holds
+    or phantom charges.
+
+    Compensation is explicit in this file: each rescue clause calls the inverse
+    operation directly (ReleaseDates, Refund, RestoreCoupon) rather than relying on
+    implicit platform wiring. The explicitness is intentional — it makes the rollback
+    story visible and auditable alongside the forward path.
+
+    Charging happens synchronously via Payments[Stripe].Charge, but payment providers
+    also confirm asynchronously via webhook. The Booking actor subscribes to
+    ChargeSucceeded and ChargeFailed events emitted by the Payments external actor.
+    On ChargeSucceeded the booking transitions from Pending to Confirmed; on
+    ChargeFailed it auto-cancels. This dual-path design means a booking placed in
+    Pending state always reaches a terminal status — the saga's sync charge is the
+    fast path and the webhook subscription is the backstop.
+  """
+
+  exports:
+    actor Booking
+    flow  PlaceBooking, PlaceBookingWithFallback, CancelBooking, CompleteBooking
+    event BookingPlaced, BookingConfirmed, BookingCancelled
+
+  uses:
+    feature listings  for HoldDates, ReleaseDates
+    feature coupons   for ValidateCoupon, RedeemCoupon, RestoreCoupon
+    external Payments for Charge, Refund, Transfer
+    external Payments for event ChargeSucceeded, ChargeFailed
+
+  policies: [BearerAuth]
+}
+
+// ---------------------------------------------------------------------------
+// Feature-local types
+// ---------------------------------------------------------------------------
+
+// CancellationReason is guest-provided free text on a cancel request.
+// Shared types (BookingStatus, Money, DateRange, ChargeId, RefundId, etc.) live
+// in types.candy and are not redeclared here.
+type CancellationReason string { max: 500 }
+
+// CancellationWindow is the output of CancellationPolicy: which tier applies
+// based on how far in the future check-in is at the time of cancellation.
+enum CancellationWindow { Free, Partial, NonRefundable }
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+actor Booking(id: Id) {
+  state {
+    listing:  Id
+    host:     Id          // denormalized from listing for fast invariant checks
+    guest:    Id
+    dates:    DateRange
+    status:   BookingStatus = Pending
+    total:    Money
+    discount: Money         = 0
+    coupon:   Id?           // present only when a coupon was redeemed
+    charge:   ChargeId?     // set when payment captures
+    refund:   RefundId?     // set on cancellation with a refund
+    created:  Timestamp
+    updated:  Timestamp
+  }
+
+  invariant total >= 0
+  invariant discount >= 0
+  invariant discount <= total + discount
+  invariant host == Listing(listing).host
+  invariant dates.from < dates.to
+
+  derive nights = dates.to - dates.from
+
+  accepts Confirm(charge: ChargeId, now: Timestamp) -> Result<unit, AlreadyConfirmed> {
+    intent: """
+      Transition a Pending booking to Confirmed. Records the charge id and
+      updates the timestamp. Idempotent guard: rejects AlreadyConfirmed if the
+      booking is already Confirmed so that duplicate webhook deliveries are safe.
+    """
+    require: status == Pending  rescue reject AlreadyConfirmed
+    effect:  status  = Confirmed
+    effect:  charge  = charge
+    effect:  updated = now
+    emit BookingConfirmed { booking: self.id, charge, at: now }
+    commit
+  }
+
+  accepts SetCancelled(reason: string, refund: RefundId?, now: Timestamp) -> unit {
+    intent: """
+      Internal helper used by the CancelBooking flow. Marks the booking Cancelled,
+      records the refund id if one was issued, and updates the timestamp. Idempotent:
+      if the booking is already Cancelled the call is a silent no-op so that the
+      ChargeFailed webhook backstop does not double-process.
+    """
+    step already = if status == Cancelled then commit
+    effect: status  = Cancelled
+    effect: refund  = refund
+    effect: updated = now
+    emit BookingCancelled { booking: self.id, reason, at: now }
+    commit
+  }
+
+  accepts Complete(now: Timestamp) -> Result<unit, AlreadyCompleted | NotConfirmed> {
+    intent: """
+      Transition a Confirmed booking to Completed. The caller is responsible for
+      invoking this only after dates.to has passed — typically via a scheduled flow
+      or admin trigger. Rejects NotConfirmed if the booking never left Pending, and
+      AlreadyCompleted if it was already marked done.
+    """
+    require: status != Completed  rescue reject AlreadyCompleted
+    require: status == Confirmed  rescue reject NotConfirmed
+    effect:  status  = Completed
+    effect:  updated = now
+    emit BookingCompleted { booking: self.id, at: now }
+    commit
+  }
+
+  // Async confirmation path: Payments fires ChargeSucceeded after the provider
+  // settles. We match on booking id so each Booking instance only reacts to
+  // its own charge event.
+  subscribe ChargeSucceeded -> on event(charge, booking, at) {
+    if booking == self.id then ask Confirm(charge, at)
+  }
+
+  // Webhook backstop: if the charge fails asynchronously (or the provider
+  // reports failure after the sync Charge call timed out), auto-cancel the
+  // booking. The booking saga's rescue clause already handles the synchronous
+  // decline; this subscriber handles the late-arriving failure notification.
+  subscribe ChargeFailed -> on event(charge, booking, reason, at) {
+    if booking == self.id then ask SetCancelled(reason, none, at)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Policies
+// ---------------------------------------------------------------------------
+
+policy CancellationPolicy {
+  intent: """
+    Hosts and guests need a deterministic, published refund schedule so
+    they can plan around cancellations. The policy divides time into three
+    windows measured from the current moment to the booking's check-in date
+    (dates.from):
+
+      - Free: more than 48 hours before check-in. The guest receives a full
+        refund. Cancelling far in advance costs neither party anything.
+
+      - Partial: between 24 and 48 hours before check-in (inclusive of the
+        48h boundary, exclusive of the 24h boundary). The guest receives 50%
+        of the total. The host is compensated for the short notice.
+
+      - NonRefundable: within 24 hours of check-in, or after check-in has
+        already started. No refund is issued. Hosts have already prepared and
+        last-minute cancellations cause real harm.
+
+    The policy also rejects BookingStarted if dates.from is already in the
+    past — you cannot cancel a booking that has already begun through this
+    flow. Completed or already-Cancelled bookings are rejected as
+    BookingNotCancellable by the CancelBooking flow before the policy runs.
+
+    Time comparisons use the now parameter — no global clock is consulted.
+  """
+  examples:
+    - given: >
+        booking with dates.from = now after 30d (30 days out),
+        cancellation requested at now
+      then: ok(Free)
+
+    - given: >
+        booking with dates.from = now after 36h (36 hours out),
+        cancellation requested at now
+      then: ok(Partial)
+
+    - given: >
+        booking with dates.from = now after 12h (12 hours out),
+        cancellation requested at now
+      then: ok(NonRefundable)
+
+    - given: >
+        booking with dates.from = now after 25h (25 hours out, just past 24h
+        threshold), cancellation requested at now
+      then: ok(NonRefundable)
+
+    - given: >
+        booking with dates.from = now after 48h (exactly 48h out),
+        cancellation requested at now (boundary is Free)
+      then: ok(Free)
+
+    - given: >
+        booking with dates.from = now after 24h (exactly 24h out),
+        cancellation requested at now (boundary is NonRefundable)
+      then: ok(NonRefundable)
+
+    - given: >
+        booking with dates.from < now (check-in already started)
+      then: err(BookingStarted)
+}
+
+policy BookingAtomicity {
+  intent: """
+    PlaceBooking commits to an all-or-nothing outcome. Either:
+
+      (a) The booking is in Pending status with all upstream side-effects fully
+          in place — the listing's calendar dates are held, the coupon (if used)
+          is redeemed, and the payment has been captured — and the saga's commit
+          block runs returning the new booking id and total; OR
+
+      (b) Every prior step has been compensated in reverse order — the coupon
+          redemption is restored, the charge is refunded, the calendar hold is
+          released — and the booking actor is never created. No booking record
+          exists; the system is back to its pre-saga state.
+
+    There is no in-between state. A booking that exists is either Pending (charge
+    captured, awaiting async webhook confirmation), Confirmed, Cancelled, or
+    Completed — never a partially-created ghost with a dangling hold or an
+    unrefunded charge sitting in limbo.
+
+    This policy is enforced at flow scope on PlaceBooking. Codegen wraps the entire
+    saga in a distributed transaction boundary; the explicit rescue chains in the
+    saga steps are the application-level specification of what that boundary means.
+    Audit tooling can verify BookingAtomicity by checking that no Booking actor
+    instance exists without a corresponding completed calendar hold and charge
+    record.
+  """
+}
+
+// ---------------------------------------------------------------------------
+// Feature-local events
+// ---------------------------------------------------------------------------
+
+// BookingCompleted is feature-local. BookingPlaced, BookingConfirmed, and
+// BookingCancelled are shared events declared in events.candy.
+event BookingCompleted {
+  payload:  { booking: Id, at: Timestamp }
+  delivery: eager
+  order:    by booking
+}
+
+// ---------------------------------------------------------------------------
+// Flows
+// ---------------------------------------------------------------------------
+
+flow PlaceBooking(
+  listing: Id,
+  guest:   Id,
+  dates:   DateRange,
+  source:  PaymentMethod,
+  code:    CouponCode?,
+  now:     Timestamp,
+  key:     Key,
+) -> Result<{ booking: Id, total: Money },
+             DatesUnavailable | CouponConflict | PaymentDeclined | InvalidBooking>
+{
+  intent: """
+    The canonical booking saga. Holds listing dates, optionally validates and
+    redeems a coupon, charges the guest, and creates the Booking actor in Pending
+    status. Every step has an explicit compensation path: if any step fails, all
+    prior steps are undone in reverse order before the error is surfaced.
+  """
+
+  policies: [BookingAtomicity]
+
+  // 0. Pre-generate the booking id so every step (and every rescue) can refer
+  //    to it. This is the key that ties HoldDates to ReleaseDates and that
+  //    Booking.create will use as its actor identity.
+  step booking_id = generate()
+
+  // 1. Hold dates on the listing's calendar. If the dates are already taken or
+  //    the listing does not exist or is not Listed, reject immediately with no
+  //    side effects to clean up.
+  step held = ask listings.HoldDates(listing, dates, booking_id, key)
+              rescue reject DatesUnavailable
+
+  // 2. Validate coupon if one was provided. This is a pure read — no state
+  //    change yet — so if it fails we only need to release the date hold.
+  step validated = if code?
+                   then ask coupons.ValidateCoupon(code, guest, now)
+                        rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                               reject CouponConflict
+                   else none
+
+  // 3. Read listing price and compute the total. Extract discount from the
+  //    validated coupon result if present.
+  step listing_actor = ask Listing.findBy(id: listing)
+                       rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                              reject InvalidBooking
+
+  step nights     = dates.to - dates.from
+  step base_total = listing_actor.pricePerNight * nights
+
+  step discount = if validated?
+                  then if validated.kind == Percent
+                       then base_total * validated.value / 100
+                       else validated.value
+                  else 0
+
+  step total = base_total - discount
+
+  // 4. Charge the guest. If the charge fails, release the date hold and reject.
+  //    This is the canonical single-provider path; PlaceBookingWithFallback
+  //    extends this step with a multi-provider rescue chain.
+  step charge = ask Payments[Stripe].Charge(total, source, key)
+                rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                       reject PaymentDeclined
+
+  // 5. Redeem the coupon now that the charge has succeeded. If redemption fails
+  //    (e.g. the coupon was exhausted by a concurrent booking between validate
+  //    and redeem), refund the charge and release the date hold.
+  step redeemed = if code?
+                  then ask coupons.RedeemCoupon(code, guest, booking_id, now, key)
+                       rescue ask Payments[Stripe].Refund(charge, none, key);
+                              ask listings.ReleaseDates(listing, dates, booking_id, key);
+                              reject CouponConflict
+                  else unit
+
+  // 6. Create the Booking actor in Pending status using the pre-generated id.
+  //    The actor will transition to Confirmed when the ChargeSucceeded webhook
+  //    arrives (or stay Pending then auto-cancel on ChargeFailed).
+  step booking = ask Booking.create({
+    id:       booking_id,
+    listing,
+    host:     listing_actor.host,
+    guest,
+    dates,
+    status:   Pending,
+    total,
+    discount,
+    coupon:   if validated? then validated.coupon else none,
+    charge:   charge,
+    refund:   none,
+    created:  now,
+    updated:  now,
+  })
+
+  emit BookingPlaced { booking: booking.id, listing, guest, dates, total, at: now }
+  commit { booking: booking.id, total }
+}
+
+flow PlaceBookingWithFallback(
+  listing: Id,
+  guest:   Id,
+  dates:   DateRange,
+  source:  PaymentMethod,
+  code:    CouponCode?,
+  now:     Timestamp,
+  key:     Key,
+) -> Result<{ booking: Id, total: Money, provider: string },
+             DatesUnavailable | CouponConflict | AllProvidersFailed | InvalidBooking>
+{
+  intent: """
+    Variant of PlaceBooking that attempts all three configured payment providers
+    in sequence before failing. Stripe is tried first; if it rejects (network
+    error, rate limit, or decline), Polar is tried next; then LemonSqueezy. If
+    all three fail the saga compensates any prior successful steps and rejects
+    AllProvidersFailed. On success, the response includes the name of the provider
+    that captured the charge so the caller can record it for support and reconciliation.
+  """
+
+  policies: [BookingAtomicity]
+
+  step booking_id = generate()
+
+  step held = ask listings.HoldDates(listing, dates, booking_id, key)
+              rescue reject DatesUnavailable
+
+  step validated = if code?
+                   then ask coupons.ValidateCoupon(code, guest, now)
+                        rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                               reject CouponConflict
+                   else none
+
+  step listing_actor = ask Listing.findBy(id: listing)
+                       rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                              reject InvalidBooking
+
+  step nights     = dates.to - dates.from
+  step base_total = listing_actor.pricePerNight * nights
+
+  step discount = if validated?
+                  then if validated.kind == Percent
+                       then base_total * validated.value / 100
+                       else validated.value
+                  else 0
+
+  step total = base_total - discount
+
+  // Try all three providers. The rescue chain falls through to the next provider
+  // on any error. If all three fail, compensate the date hold and reject.
+  step charge = ask Payments[Stripe].Charge(total, source, key)
+                rescue ask Payments[Polar].Charge(total, source, key)
+                rescue ask Payments[Lemon].Charge(total, source, key)
+                rescue ask listings.ReleaseDates(listing, dates, booking_id, key);
+                       reject AllProvidersFailed
+
+  // Identify which provider succeeded by tagging the charge result.
+  step provider = charge.provider
+
+  step redeemed = if code?
+                  then ask coupons.RedeemCoupon(code, guest, booking_id, now, key)
+                       rescue ask Payments[Stripe].Refund(charge, none, key);
+                              ask listings.ReleaseDates(listing, dates, booking_id, key);
+                              reject CouponConflict
+                  else unit
+
+  step booking = ask Booking.create({
+    id:       booking_id,
+    listing,
+    host:     listing_actor.host,
+    guest,
+    dates,
+    status:   Pending,
+    total,
+    discount,
+    coupon:   if validated? then validated.coupon else none,
+    charge:   charge,
+    refund:   none,
+    created:  now,
+    updated:  now,
+  })
+
+  emit BookingPlaced { booking: booking.id, listing, guest, dates, total, at: now }
+  commit { booking: booking.id, total, provider }
+}
+
+flow CancelBooking(
+  booking: Id,
+  reason:  string,
+  now:     Timestamp,
+  key:     Key,
+) -> Result<{ refund: Money }, BookingNotFound | BookingNotCancellable | BookingStarted>
+{
+  intent: """
+    Cancel a booking and issue the appropriate refund based on the cancellation
+    window. The refund tier is determined by CancellationPolicy. After refunding
+    (if any), the coupon is restored (if one was redeemed), the listing calendar
+    dates are released, and the Booking actor is moved to Cancelled status.
+    All operations after the policy check are idempotent on key.
+  """
+
+  policies: [CancellationPolicy]
+
+  // 1. Load the booking. Reject immediately if it does not exist.
+  step b = ask Booking.findBy(id: booking)
+           rescue reject BookingNotFound
+
+  // 2. Guard: only Pending and Confirmed bookings can be cancelled.
+  step _ = if b.status != Pending and b.status != Confirmed
+           then reject BookingNotCancellable
+
+  // 3. Determine the refund window. BookingStarted is surfaced by the policy
+  //    when dates.from < now.
+  step window = ask CancellationPolicy(b, now)
+                rescue reject BookingStarted
+
+  // 4. Compute the refund amount from the window.
+  step refund_amount = if window == Free        then b.total
+                       else if window == Partial then b.total / 2
+                       else                          0
+
+  // 5. Issue the refund if one is owed.
+  step refund_id = if refund_amount > 0
+                   then ask Payments[Stripe].Refund(b.charge, refund_amount, key)
+                        rescue reject BookingNotCancellable
+                   else none
+
+  // 6. Restore coupon if one was applied to this booking.
+  step _ = if b.coupon?
+           then ask coupons.RestoreCoupon(b.coupon, booking, key)
+
+  // 7. Release the calendar hold for these dates.
+  step _ = ask listings.ReleaseDates(b.listing, b.dates, booking, key)
+
+  // 8. Mark the booking cancelled.
+  step _ = ask Booking(booking).SetCancelled(reason, refund_id, now)
+
+  commit { refund: refund_amount }
+}
+
+flow CompleteBooking(
+  booking: Id,
+  now:     Timestamp,
+  key:     Key,
+) -> Result<{ transfer: TransferId },
+             BookingNotFound | NotConfirmed | AlreadyCompleted | BookingNotEnded>
+{
+  intent: """
+    Complete a booking after check-out and transfer the host payout. The platform
+    retains a 12% fee; the host receives 88% of the total. Transfer failures are
+    logged but do not reject the flow — payout retry is handled separately by a
+    scheduled job so a failing transfer does not block the booking from reaching
+    Completed status. This flow is admin-triggered in the example; in production
+    it would be driven by a schedule firing at dates.to.
+  """
+
+  // 1. Load the booking.
+  step b = ask Booking.findBy(id: booking)
+           rescue reject BookingNotFound
+
+  // 2. Reject if the stay has not yet ended.
+  step _ = if now < b.dates.to
+           then reject BookingNotEnded
+
+  // 3. Mark the booking Completed. Rejects NotConfirmed or AlreadyCompleted.
+  step _ = ask Booking(booking).Complete(now)
+           rescue reject err
+
+  // 4. Compute host payout: total minus 12% platform fee (rounded to nearest
+  //    minor unit per the Money type's round: nearest policy).
+  step platform_fee = b.total * 12 / 100
+  step payout       = b.total - platform_fee
+
+  // 5. Transfer payout to host. On failure we log and continue — the booking is
+  //    already Completed and a transfer retry can be attempted independently.
+  step transfer = ask Payments[Stripe].Transfer(b.host, payout, key)
+                  rescue tell Analytics.Track({ event: "transfer_failed", booking, at: now })
+
+  commit { transfer }
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+policy BookingAccess {
+  intent: """
+    The caller must be one of: (a) the guest who placed the booking, (b) the host
+    of the listing the booking is for, or (c) a user with the Admin role. Any other
+    authenticated user is rejected NotAuthorized. This policy is attached at
+    route scope on the booking read endpoint.
+  """
+  examples:
+    - given: caller id == booking.guest
+      then:  ok
+
+    - given: caller id == booking.host
+      then:  ok
+
+    - given: caller has role Admin
+      then:  ok
+
+    - given: caller is a different guest (not the booking's guest or host)
+      then:  err(NotAuthorized)
+}
+
+controller Bookings {
+  policies: [BearerAuth]
+
+  POST /bookings -> PlaceBooking(body.listing, self, body.dates, body.source, body.code, now, body.idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Guest)]
+    body: {
+      listing:          Id,
+      dates:            DateRange,
+      source:           PaymentMethod,
+      code:             CouponCode?,
+      idempotency_key:  Key,
+    }
+    map:
+      ok(r)                          -> 201 { booking_id: r.booking, total: r.total }
+      err(DatesUnavailable)          -> 409 { error: "dates_unavailable" }
+      err(CouponConflict)            -> 422 { error: "coupon_conflict" }
+      err(PaymentDeclined)           -> 402 { error: "payment_declined" }
+      err(InvalidBooking reason)     -> 422 { error: "invalid_booking", reason }
+  }
+
+  POST /bookings/with-fallback -> PlaceBookingWithFallback(body.listing, self, body.dates, body.source, body.code, now, body.idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Guest)]
+    body: {
+      listing:          Id,
+      dates:            DateRange,
+      source:           PaymentMethod,
+      code:             CouponCode?,
+      idempotency_key:  Key,
+    }
+    map:
+      ok(r)                          -> 201 { booking_id: r.booking, total: r.total, provider: r.provider }
+      err(DatesUnavailable)          -> 409 { error: "dates_unavailable" }
+      err(CouponConflict)            -> 422 { error: "coupon_conflict" }
+      err(AllProvidersFailed)        -> 502 { error: "all_providers_failed" }
+      err(InvalidBooking reason)     -> 422 { error: "invalid_booking", reason }
+  }
+
+  POST /bookings/:id/cancel -> CancelBooking(id, body.reason, now, body.idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Guest)]
+    body: {
+      reason:           CancellationReason,
+      idempotency_key:  Key,
+    }
+    map:
+      ok(r)                              -> 200 { refund: r.refund }
+      err(BookingNotFound)               -> 404 { error: "booking_not_found" }
+      err(BookingNotCancellable reason)  -> 409 { error: "booking_not_cancellable", reason }
+      err(BookingStarted)                -> 409 { error: "booking_started" }
+  }
+
+  POST /bookings/:id/complete -> CompleteBooking(id, now, body.idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Admin)]
+    body: { idempotency_key: Key }
+    map:
+      ok(r)                  -> 200 { transfer_id: r.transfer }
+      err(BookingNotFound)   -> 404 { error: "booking_not_found" }
+      err(NotConfirmed)      -> 409 { error: "not_confirmed" }
+      err(AlreadyCompleted)  -> 409 { error: "already_completed" }
+      err(BookingNotEnded)   -> 409 { error: "booking_not_ended" }
+  }
+
+  GET /bookings/:id -> Booking(id) {
+    auth: bearer
+    policies: [BookingAccess]
+    map:
+      ok(b)              -> 200 b
+      err(NotFound)      -> 404 { error: "booking_not_found" }
+      err(NotAuthorized) -> 403 { error: "not_authorized" }
+  }
+}

--- a/examples/airbnb/coupons.candy
+++ b/examples/airbnb/coupons.candy
@@ -1,0 +1,361 @@
+// coupons.candy — promotional coupon management for the airbnb marketplace.
+//
+// Leaf feature: no cross-feature dependencies. Exports the validate/redeem/restore
+// interface consumed by the booking saga.
+
+prose {
+  intent: """
+    Coupons are platform-issued discount codes that reduce the price of a
+    booking. Admins create coupons with a kind (percentage off or fixed
+    dollar amount), a value, a maximum number of redemptions, and an
+    expiry timestamp. Guests apply a coupon code during checkout; the
+    booking saga validates eligibility before charging and redeems the
+    coupon after a successful charge.
+
+    A coupon is eligible when it exists, has not expired, has not been
+    exhausted across all users, and has not already been redeemed by the
+    requesting user. Eligibility is a pure check; redemption is the
+    state-changing step. The restore operation undoes a redemption — used
+    by the booking saga's compensation path when a downstream step fails
+    after the coupon was already redeemed.
+  """
+
+  exports:
+    actor Coupon
+    flow  CreateCoupon, DeleteCoupon, ValidateCoupon, RedeemCoupon, RestoreCoupon
+    event CouponCreated, CouponRedeemed, CouponRestored
+
+  policies: [BearerAuth]
+}
+
+// Feature-local record type. Not in shared types — it is private to this
+// feature and only appears in the Coupon actor's redemptions journal.
+type Redemption {
+  user:    Id
+  booking: Id
+  at:      Timestamp
+}
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+actor Coupon(code: CouponCode) {
+  state {
+    kind:        CouponKind
+    value:       int
+    maxUses:     int
+    expires:     Timestamp
+    created:     Timestamp
+    redemptions: [Redemption]
+  }
+
+  // Percent coupons express value as 1–100 (the discount percentage).
+  // FixedAmount coupons express value in Money minor units (e.g. 500 = $5.00).
+  invariant kind == Percent     => value >= 1 and value <= 100
+  invariant kind == FixedAmount => value > 0
+  invariant length(redemptions) <= maxUses
+  invariant expires > created
+
+  // Structural shape invariant: each user appears at most once in the journal.
+  // CouponEligibility enforces the prose-level rule; this guards the data shape.
+  invariant "all redemptions[i].user values are distinct"
+
+  // True when the coupon can still accept new redemptions right now.
+  derive available = length(redemptions) < maxUses and now < expires
+
+  accepts Redeem(user: Id, booking: Id, now: Timestamp, key: Key)
+    -> Result<unit, AlreadyRedeemed | Exhausted | Expired>
+  {
+    intent: """
+      Append a redemption to the journal if the coupon is still available
+      and this user has not already redeemed it. Idempotent on key — a
+      replay with the same key returns ok without re-appending.
+    """
+    require: not any r in redemptions where r.user == user
+             rescue reject AlreadyRedeemed
+    require: length(redemptions) < maxUses
+             rescue reject Exhausted
+    require: now < expires
+             rescue reject Expired
+    effect:  redemptions = redemptions + [{ user, booking, at: now }]
+    emit CouponRedeemed { coupon: self.code, user, booking, at: now }
+    commit
+  }
+
+  accepts Restore(booking: Id, key: Key) -> unit {
+    intent: """
+      Remove the redemption matching this booking from the journal.
+      Idempotent — if no matching redemption exists the call is a no-op.
+      Used by the booking saga compensation path.
+    """
+    effect:  redemptions = redemptions where redemptions.booking != booking
+    emit CouponRestored { coupon: self.code, booking, at: now }
+    commit
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+policy CouponEligibility {
+  intent: """
+    A coupon is eligible to redeem when all four conditions hold:
+
+      - it exists: the code resolves to a known Coupon actor.
+      - it has not expired: now < expires (strictly before the expiry
+        timestamp, so a coupon that expires at midnight is unusable at
+        midnight).
+      - it has not been exhausted: length(redemptions) < maxUses, meaning
+        at least one redemption slot remains across all users.
+      - the requesting user has not already redeemed it: no entry in the
+        coupon's redemptions journal carries this user's id.
+
+    Eligibility is evaluated before redemption so that callers receive a
+    typed error that pinpoints the exact failure mode rather than a generic
+    rejection from the actor. ValidateCoupon exposes this check as a
+    read-only preview (used by the checkout UI); RedeemCoupon re-evaluates
+    it immediately before mutating state so the two steps are never
+    inconsistent in a concurrent system.
+
+    Error variants are intentionally distinct — CouponNotFound, Expired,
+    Exhausted, AlreadyRedeemed — because the checkout UI must surface
+    different copy for each. "This code doesn't exist" and "you've already
+    used this code" are meaningfully different user experiences.
+  """
+  examples:
+    - given: >
+        code "SAVE10" resolves to a Percent coupon (value=10, maxUses=100),
+        length(redemptions)=42, expires=2027-01-01T00:00:00Z,
+        now=2026-06-15T12:00:00Z, requesting user has no prior redemption
+      then: ok({ coupon: <id>, kind: Percent, value: 10 })
+
+    - given: >
+        code "GHOST99" does not resolve to any Coupon actor
+      then: err(CouponNotFound)
+
+    - given: >
+        code "SUMMER20" resolves to a valid coupon, but
+        now=2026-09-01T00:00:00Z > expires=2026-08-31T23:59:59Z
+      then: err(Expired)
+
+    - given: >
+        code "FLASH50" resolves to a FixedAmount coupon (maxUses=5),
+        length(redemptions)=5 (all slots consumed), now is before expires,
+        requesting user has no prior redemption
+      then: err(Exhausted)
+
+    - given: >
+        code "WELCOME5" resolves to a valid, non-exhausted, non-expired coupon,
+        but the requesting user's id already appears in redemptions
+      then: err(AlreadyRedeemed)
+
+    - given: >
+        code "NEWYEAR" resolves to a valid coupon,
+        now=expires exactly (not strictly before)
+      then: err(Expired)
+}
+
+// ---------------------------------------------------------------------------
+// Flows
+// ---------------------------------------------------------------------------
+
+flow CreateCoupon(
+  code:    CouponCode,
+  kind:    CouponKind,
+  value:   int,
+  maxUses: int,
+  expires: Timestamp,
+  now:     Timestamp,
+  key:     Key
+) -> Result<{ coupon: Id }, InvalidCoupon | CodeTaken>
+{
+  intent: """
+    Create a new coupon. Validates that the value is within bounds for the
+    given kind, that maxUses is at least 1, and that the expiry is in the
+    future. Rejects CodeTaken if a coupon with this code already exists.
+    Idempotent on key.
+  """
+
+  step bounds = if kind == Percent and (value < 1 or value > 100)
+                then reject InvalidCoupon("percent value must be 1–100")
+
+  step bounds2 = if kind == FixedAmount and value <= 0
+                 then reject InvalidCoupon("fixed amount value must be positive")
+
+  step uses    = if maxUses < 1
+                 then reject InvalidCoupon("maxUses must be at least 1")
+
+  step future  = if expires <= now
+                 then reject InvalidCoupon("expires must be in the future")
+
+  step taken   = if any c in Coupon where c.code == code
+                 then reject CodeTaken
+
+  step coupon  = ask Coupon.create({
+                   code,
+                   kind,
+                   value,
+                   maxUses,
+                   expires,
+                   created:     now,
+                   redemptions: [],
+                 })
+
+  emit CouponCreated { coupon: coupon.code, code, at: now }
+  commit { coupon: coupon.code }
+}
+
+flow DeleteCoupon(coupon: Id, now: Timestamp, key: Key)
+  -> Result<unit, CouponNotFound | CouponInUse>
+{
+  intent: """
+    Delete a coupon. Rejects CouponInUse if the coupon has any redemptions,
+    because deleting a redeemed coupon would leave bookings referencing a
+    non-existent discount. Idempotent on key.
+  """
+
+  step c    = ask Coupon.findBy(id: coupon)
+              rescue reject CouponNotFound
+
+  step live = if length(c.redemptions) > 0
+              then reject CouponInUse
+
+  effect: Coupon(coupon).delete()
+  commit
+}
+
+flow ValidateCoupon(code: CouponCode, user: Id, now: Timestamp)
+  -> Result<{ coupon: Id, kind: CouponKind, value: int },
+             CouponNotFound | Expired | Exhausted | AlreadyRedeemed>
+{
+  intent: """
+    Pure eligibility check — no state change. Governed by CouponEligibility.
+    Returns the coupon's discount parameters on success so the booking
+    checkout UI can compute and display the discounted price before the
+    user confirms. The booking saga calls this before charging; the
+    RedeemCoupon flow re-evaluates eligibility at the time of actual
+    redemption.
+  """
+
+  step c = ask Coupon.findBy(code)
+           rescue reject CouponNotFound
+
+  step _ = if now >= c.expires
+           then reject Expired
+
+  step _ = if length(c.redemptions) >= c.maxUses
+           then reject Exhausted
+
+  step _ = if any r in c.redemptions where r.user == user
+           then reject AlreadyRedeemed
+
+  commit { coupon: c.code, kind: c.kind, value: c.value }
+}
+
+flow RedeemCoupon(
+  code:    CouponCode,
+  user:    Id,
+  booking: Id,
+  now:     Timestamp,
+  key:     Key
+) -> Result<unit, CouponNotFound | Expired | Exhausted | AlreadyRedeemed>
+{
+  intent: """
+    Redeem a coupon on behalf of a user for a specific booking. Governed by
+    CouponEligibility at flow scope — eligibility is re-checked immediately
+    before asking the actor to mutate state. Idempotent on key: replaying
+    the same key returns ok without double-appending. Called by the booking
+    saga after a charge succeeds; compensation is RestoreCoupon.
+  """
+
+  policies: [CouponEligibility]
+
+  step c = ask Coupon.findBy(code)
+           rescue reject CouponNotFound
+
+  step _ = ask Coupon(c.code).Redeem(user, booking, now, key)
+           rescue reject err
+}
+
+flow RestoreCoupon(coupon: Id, booking: Id, key: Key) -> unit {
+  intent: """
+    Idempotent unredeem. Removes the redemption matching the booking from
+    the coupon's journal. Called by the booking saga's compensation path
+    when a step after RedeemCoupon fails (e.g. a downstream transfer).
+    If no matching redemption exists the call is a silent no-op.
+  """
+
+  step c = ask Coupon.findBy(id: coupon)
+           rescue commit
+
+  step _ = ask Coupon(c.code).Restore(booking, key)
+  commit
+}
+
+// ---------------------------------------------------------------------------
+// Policies (admin gate + role check)
+// ---------------------------------------------------------------------------
+
+policy AdminGated {
+  intent: """
+    The caller's session-bound role must be Admin. Any authenticated user
+    whose role is Guest or Host is rejected. This policy is attached at
+    route scope on admin-only endpoints; BearerAuth (feature-scope) runs
+    first to establish the session, then AdminGated checks the role.
+  """
+  examples:
+    - given: authenticated user with role Admin
+      then:  ok
+
+    - given: authenticated user with role Host
+      then:  err(NotAdmin)
+
+    - given: authenticated user with role Guest
+      then:  err(NotAdmin)
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+controller Coupons {
+  // Admin coupon management — BearerAuth is feature-scoped; AdminGated added
+  // per-route for the mutating admin endpoints.
+
+  POST /admin/coupons -> CreateCoupon(body.code, body.kind, body.value, body.maxUses, body.expires, now, idempotency_key) {
+    auth: bearer
+    policies: [AdminGated]
+    body: { code: CouponCode, kind: CouponKind, value: int, maxUses: int, expires: Timestamp, idempotency_key: Key }
+    map:
+      ok(result)                      -> 201 { coupon_id: result.coupon }
+      err(InvalidCoupon reason)       -> 422 { error: "invalid_coupon", reason }
+      err(CodeTaken)                  -> 409 { error: "code_taken" }
+  }
+
+  DELETE /admin/coupons/:id -> DeleteCoupon(id, now, idempotency_key) {
+    auth: bearer
+    policies: [AdminGated]
+    body: { idempotency_key: Key }
+    map:
+      ok(_)                -> 204
+      err(CouponNotFound)  -> 404 { error: "coupon_not_found" }
+      err(CouponInUse)     -> 409 { error: "coupon_in_use" }
+  }
+
+  // Any authenticated user can validate a coupon code to preview the discount.
+  // No AdminGated — guests use this at checkout before confirming a booking.
+  GET /coupons/:code/validate -> ValidateCoupon(code, self, now) {
+    auth: bearer
+    map:
+      ok(result)           -> 200 { coupon_id: result.coupon, kind: result.kind, value: result.value }
+      err(CouponNotFound)  -> 404 { error: "coupon_not_found" }
+      err(Expired)         -> 410 { error: "coupon_expired" }
+      err(Exhausted)       -> 410 { error: "coupon_exhausted" }
+      err(AlreadyRedeemed) -> 409 { error: "already_redeemed" }
+  }
+
+  // RedeemCoupon and RestoreCoupon are not exposed as HTTP endpoints.
+  // They are called exclusively by the booking saga via flow invocation.
+}

--- a/examples/airbnb/events.candy
+++ b/examples/airbnb/events.candy
@@ -1,0 +1,27 @@
+// events.candy — cross-feature events for the airbnb example.
+//
+// Only events that cross feature boundaries live here. Per-feature events
+// (emitted and consumed within one feature) are declared in that feature's
+// file. All events use delivery: eager unless noted; ordering is by the
+// most relevant identifier so subscribers can dedupe.
+
+// auth events
+event UserSignedUp   { payload: { user: Id, email: Email, at: Timestamp }, delivery: eager }
+event UserVerified   { payload: { user: Id, at: Timestamp },               delivery: eager }
+event UserLoggedIn   { payload: { user: Id, at: Timestamp },               delivery: eager, order: by user }
+event SessionRevoked { payload: { token: Token, user: Id, at: Timestamp }, delivery: eager }
+
+// listings events
+event ListingCreated { payload: { listing: Id, host: Id, at: Timestamp }, delivery: eager, order: by listing }
+event ListingUpdated { payload: { listing: Id, at: Timestamp },           delivery: eager, order: by listing }
+event ListingHidden  { payload: { listing: Id, at: Timestamp },           delivery: eager, order: by listing }
+
+// coupons events
+event CouponCreated  { payload: { coupon: Id, code: CouponCode, at: Timestamp },            delivery: eager }
+event CouponRedeemed { payload: { coupon: Id, user: Id, booking: Id, at: Timestamp },       delivery: eager, order: by coupon }
+event CouponRestored { payload: { coupon: Id, booking: Id, at: Timestamp },                 delivery: eager, order: by coupon }
+
+// booking events
+event BookingPlaced    { payload: { booking: Id, listing: Id, guest: Id, dates: DateRange, total: Money, at: Timestamp }, delivery: eager, order: by booking }
+event BookingConfirmed { payload: { booking: Id, charge: ChargeId, at: Timestamp },         delivery: eager, order: by booking }
+event BookingCancelled { payload: { booking: Id, reason: string, at: Timestamp },           delivery: eager, order: by booking }

--- a/examples/airbnb/externals.candy
+++ b/examples/airbnb/externals.candy
@@ -1,0 +1,31 @@
+// externals.candy — external actor declarations for the airbnb example.
+//
+// Payments supports three live providers simultaneously. The booking saga
+// selects a provider at the call site via Payments[Tag]. Webhook routes for
+// all three emits are codegen-derived — no controller declaration needed.
+
+external actor Payments {
+  intent: "Payment provider — charges, refunds, and host transfers across Stripe, Polar, and LemonSqueezy."
+
+  providers: [Stripe, Polar, Lemon]
+
+  config Stripe: api_key:        secret "STRIPE_KEY"
+                 webhook_secret: secret "STRIPE_WEBHOOK_SECRET"
+  config Polar:  api_key:        secret "POLAR_KEY"
+                 webhook_secret: secret "POLAR_WEBHOOK_SECRET"
+  config Lemon:  api_key:        secret "LEMONSQUEEZY_KEY"
+                 webhook_secret: secret "LEMONSQUEEZY_WEBHOOK_SECRET"
+
+  accepts Charge(amount: Money, source: PaymentMethod, key: Key)
+    -> Result<ChargeId, PaymentDeclined | NetworkError | RateLimited>
+
+  accepts Refund(charge: ChargeId, amount: Money?, key: Key)
+    -> Result<RefundId, RefundError | NetworkError>
+
+  accepts Transfer(to: Id, amount: Money, key: Key)
+    -> Result<TransferId, TransferFailed | NetworkError>
+
+  emits ChargeSucceeded { charge: ChargeId, booking: Id, at: Timestamp }
+  emits ChargeFailed    { charge: ChargeId, booking: Id, reason: string, at: Timestamp }
+  emits RefundProcessed { refund: RefundId, charge: ChargeId, at: Timestamp }
+}

--- a/examples/airbnb/invariants.candy
+++ b/examples/airbnb/invariants.candy
@@ -1,0 +1,16 @@
+// invariants.candy — system-wide invariants for the airbnb example.
+//
+// These truths span multiple features and cannot be owned by any single
+// actor. Each is enforced by conformance tests generated from the spec.
+
+invariant SlotIntegrity:
+  "no two Confirmed bookings share a (listing, date) tuple"
+
+invariant CouponSingleUse:
+  "a coupon is redeemed at most once per (coupon, user) pair"
+
+invariant BookingHostMatchesListing:
+  "for any Booking b: b.host == Listing(b.listing).host"
+
+invariant SessionUserConsistency:
+  "for any active Session s: User(s.user) exists and is verified"

--- a/examples/airbnb/listings.candy
+++ b/examples/airbnb/listings.candy
@@ -1,0 +1,330 @@
+// listings.candy — property listings and calendar hold-set.
+prose {
+  intent: """
+    Listings owns the Listing and Calendar actors. A Listing is a host's
+    property record — title, location, pricing, guest cap, and lifecycle
+    status (Draft → Listed → Hidden). A Calendar is the day-by-day held-set
+    for a listing; it tracks which dates are reserved by which booking so
+    the booking saga can atomically hold and release date ranges without
+    double-booking.
+
+    The booking feature depends on this feature exclusively through two
+    exported flows: HoldDates and ReleaseDates. Both are idempotent on key.
+    All other flows are host-facing CRUD. ListListings is public and supports
+    availability filtering so guests can search open date ranges.
+  """
+
+  exports:
+    actor Listing, Calendar
+    flow  CreateListing, UpdateListing, ListListings, HoldDates, ReleaseDates
+    event ListingCreated, ListingUpdated, ListingHidden
+
+  uses:
+    feature auth for event UserSignedUp
+
+  policies: [BearerAuth]
+}
+
+enum ListingFilter { All, Listed, ByHost, AvailableInRange }
+
+type HeldEntry {
+  date:    Date
+  booking: Id
+}
+
+actor Listing(id: Id) {
+  state {
+    host:          Id
+    title:         string
+    description:   string
+    location:      string
+    pricePerNight: Money
+    maxGuests:     int
+    status:        ListingStatus = Draft
+    created:       Timestamp
+    updated:       Timestamp
+  }
+
+  invariant pricePerNight > 0
+  invariant maxGuests >= 1
+  invariant maxGuests <= 16
+  invariant "title max 200 characters"
+  invariant "description max 5000 characters"
+  invariant "location max 200 characters"
+
+  derive listed = status == Listed
+
+  accepts UpdateMeta(
+    title:         string?,
+    description:   string?,
+    location:      string?,
+    pricePerNight: Money?,
+    maxGuests:     int?,
+    now:           Timestamp,
+  ) -> Result<unit, InvalidUpdate> {
+    intent: "Apply any supplied optional fields and advance the updated timestamp."
+    effect: title         = title         if title         else self.title
+    effect: description   = description   if description   else self.description
+    effect: location      = location      if location      else self.location
+    effect: pricePerNight = pricePerNight if pricePerNight else self.pricePerNight
+    effect: maxGuests     = maxGuests     if maxGuests     else self.maxGuests
+    effect: updated       = now
+    emit ListingUpdated { listing: self.id, at: now }
+    commit
+  }
+
+  accepts Publish(now: Timestamp) -> Result<unit, AlreadyListed | DraftIncomplete> {
+    intent: "Transition a Draft listing to Listed. Requires title, description, and pricePerNight."
+    require: status != Listed                               rescue reject AlreadyListed
+    require: length(title) > 0                             rescue reject DraftIncomplete
+    require: length(description) > 0                       rescue reject DraftIncomplete
+    require: pricePerNight > 0                             rescue reject DraftIncomplete
+    effect:  status  = Listed
+    effect:  updated = now
+    commit
+  }
+
+  accepts Hide(now: Timestamp) -> Result<unit, AlreadyHidden> {
+    intent: "Transition a Listed or Draft listing to Hidden. Emits ListingHidden."
+    require: status != Hidden  rescue reject AlreadyHidden
+    effect:  status  = Hidden
+    effect:  updated = now
+    emit ListingHidden { listing: self.id, at: now }
+    commit
+  }
+}
+
+actor Calendar(listing: Id) {
+  state {
+    held: [HeldEntry]
+  }
+
+  invariant "held is unique by (date, booking) — no duplicate (date, booking) pairs"
+
+  derive heldDates = held.date
+
+  accepts Hold(
+    dates:   DateRange,
+    booking: Id,
+    key:     Key,
+  ) -> Result<unit, DatesUnavailable> {
+    intent: """
+      Reserve every date in the range for the given booking. Rejects
+      DatesUnavailable if any date in the range is already held by a
+      different booking. Idempotent on key: replaying with the same key
+      returns ok without re-appending.
+    """
+    require: not any entry in held
+             where entry.date in dates and entry.booking != booking
+             rescue reject DatesUnavailable
+    effect: held = held + [{ date: d, booking } for d in dates
+                            where not any e in held where e.date == d and e.booking == booking]
+    commit
+  }
+
+  accepts Release(
+    dates:   DateRange,
+    booking: Id,
+    key:     Key,
+  ) -> unit {
+    intent: """
+      Remove all (date, booking) entries matching the given booking in the
+      given range. Idempotent — releasing already-released dates is a no-op.
+    """
+    effect: held = held where not (held.date in dates and held.booking == booking)
+    commit
+  }
+}
+
+policy ListingOwner {
+  intent: """
+    The authenticated caller must be the listing's host. Admin users bypass
+    this check. Guests and other hosts are rejected with NotOwner.
+  """
+  examples:
+    - given: caller is host of listing
+      then:  ok
+    - given: caller is a different host
+      then:  err(NotOwner)
+    - given: caller has role Admin
+      then:  ok
+    - given: caller has role Guest
+      then:  err(NotOwner)
+}
+
+flow CreateListing(
+  host:          Id,
+  title:         string,
+  description:   string,
+  location:      string,
+  pricePerNight: Money,
+  maxGuests:     int,
+  now:           Timestamp,
+  key:           Key,
+) -> Result<{ listing: Id }, InvalidListing> {
+  intent: "Create a new Listing in Draft status for the given host."
+
+  step listing = ask Listing.create({
+    id:            generate(),
+    host,
+    title,
+    description,
+    location,
+    pricePerNight,
+    maxGuests,
+    status:        Draft,
+    created:       now,
+    updated:       now,
+  })
+                 rescue reject InvalidListing
+
+  emit ListingCreated { listing: listing.id, host, at: now }
+  commit { listing: listing.id }
+}
+
+flow UpdateListing(
+  listing:       Id,
+  title:         string?,
+  description:   string?,
+  location:      string?,
+  pricePerNight: Money?,
+  maxGuests:     int?,
+  now:           Timestamp,
+  key:           Key,
+) -> Result<unit, InvalidUpdate | ListingNotFound> {
+  intent: "Apply a partial update to an existing listing's metadata."
+
+  step l = ask Listing.findBy(id: listing)  rescue reject ListingNotFound
+  step _ = ask Listing(listing).UpdateMeta(title, description, location, pricePerNight, maxGuests, now)
+               rescue reject InvalidUpdate
+  commit
+}
+
+flow PublishListing(listing: Id, now: Timestamp, key: Key)
+  -> Result<unit, AlreadyListed | DraftIncomplete | ListingNotFound>
+{
+  intent: "Move a Draft listing to Listed, making it visible to guests."
+  step l = ask Listing.findBy(id: listing)  rescue reject ListingNotFound
+  step _ = ask Listing(listing).Publish(now)
+               rescue reject AlreadyListed | DraftIncomplete
+  commit
+}
+
+flow HideListing(listing: Id, now: Timestamp, key: Key)
+  -> Result<unit, AlreadyHidden | ListingNotFound>
+{
+  intent: "Move a Listed or Draft listing to Hidden, removing it from search."
+  step l = ask Listing.findBy(id: listing)  rescue reject ListingNotFound
+  step _ = ask Listing(listing).Hide(now)
+               rescue reject AlreadyHidden
+  commit
+}
+
+flow ListListings(
+  filter: ListingFilter,
+  host:   Id?,
+  dates:  DateRange?,
+) -> [Listing] {
+  intent: """
+    Query listings by filter. Listed is the default. ByHost returns all
+    listings for the given host regardless of status. AvailableInRange
+    returns Listed listings whose Calendar.heldDates do not overlap the
+    input dates — used by the guest search surface.
+  """
+
+  step results =
+    if filter == All            then any l in Listing
+    else if filter == Listed    then any l in Listing where l.status == Listed
+    else if filter == ByHost    then any l in Listing where l.host == host
+    else if filter == AvailableInRange
+      then any l in Listing
+           where l.status == Listed
+             and not any d in Calendar(l.id).heldDates where d in dates
+
+  commit results
+}
+
+flow HoldDates(listing: Id, dates: DateRange, booking: Id, key: Key)
+  -> Result<unit, DatesUnavailable | ListingNotFound | ListingNotListed>
+{
+  intent: "Booking saga entry point. Verify listing exists and is Listed, then hold dates. Idempotent on key."
+  step l = ask Listing.findBy(id: listing)   rescue reject ListingNotFound
+  step _ = if l.status != Listed             then reject ListingNotListed
+  step _ = ask Calendar(listing).Hold(dates, booking, key)
+               rescue reject DatesUnavailable
+  commit
+}
+
+flow ReleaseDates(listing: Id, dates: DateRange, booking: Id, key: Key) -> unit {
+  intent: "Booking saga compensation. Unconditionally releases held entries for (dates, booking). Idempotent."
+  step _ = ask Calendar(listing).Release(dates, booking, key)
+  commit
+}
+
+controller Listings {
+  POST /listings -> CreateListing(self, body.title, body.description, body.location, body.pricePerNight, body.maxGuests, now, idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Host)]
+    body: {
+      title:           string,
+      description:     string,
+      location:        string,
+      pricePerNight:   Money,
+      maxGuests:       int,
+      idempotency_key: Key,
+    }
+    map:
+      ok(result)                    -> 201 { listing_id: result.listing }
+      err(InvalidListing reason)    -> 422 { error: "invalid_listing", reason }
+  }
+
+  PATCH /listings/:id -> UpdateListing(id, body.title, body.description, body.location, body.pricePerNight, body.maxGuests, now, idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Host), ListingOwner]
+    body: {
+      title?:          string,
+      description?:    string,
+      location?:       string,
+      pricePerNight?:  Money,
+      maxGuests?:      int,
+      idempotency_key: Key,
+    }
+    map:
+      ok(_)                         -> 200
+      err(InvalidUpdate reason)     -> 422 { error: "invalid_update", reason }
+      err(ListingNotFound)          -> 404 { error: "listing_not_found" }
+  }
+
+  POST /listings/:id/publish -> PublishListing(id, now, idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Host), ListingOwner]
+    body: { idempotency_key: Key }
+    map:
+      ok(_)                         -> 200
+      err(AlreadyListed)            -> 409 { error: "already_listed" }
+      err(DraftIncomplete reason)   -> 422 { error: "draft_incomplete", reason }
+      err(ListingNotFound)          -> 404 { error: "listing_not_found" }
+  }
+
+  POST /listings/:id/hide -> HideListing(id, now, idempotency_key) {
+    auth: bearer
+    policies: [RoleGated(Host), ListingOwner]
+    body: { idempotency_key: Key }
+    map:
+      ok(_)                         -> 200
+      err(AlreadyHidden)            -> 409 { error: "already_hidden" }
+      err(ListingNotFound)          -> 404 { error: "listing_not_found" }
+  }
+
+  GET /listings -> ListListings(query.filter, query.host, query.dates) {
+    auth: none
+    query: {
+      filter: ListingFilter = Listed,
+      host:   Id?,
+      from:   Date?,
+      to:     Date?,
+    }
+    map:
+      ok(list) -> 200 { listings: list }
+  }
+}

--- a/examples/airbnb/preferences.candy
+++ b/examples/airbnb/preferences.candy
@@ -5,12 +5,18 @@ target go {
   when need database  use sqlc
   when need id        use ksuid
   when need hash      use argon2
+  when need stripe    use stripe-go
+  when need polar     use polar-go
+  when need lemon     use lemonsqueezy-go
 }
 
 target rust {
   when need database  use sqlx
   when need id        use uuid-v7
   when need hash      use argon2
+  when need stripe    use async-stripe
+  when need polar     use polar-rust
+  when need lemon     use lemonsqueezy-rs
 }
 
 target typescript {
@@ -19,6 +25,9 @@ target typescript {
   when need id        use cuid2
   when need database  use drizzle
   when need hash      use argon2
+  when need stripe    use stripe-node
+  when need polar     use polarsh-sdk
+  when need lemon     use lemonsqueezy-js
 }
 
 target python {
@@ -26,4 +35,7 @@ target python {
   when need id        use ulid
   when need database  use sqlalchemy
   when need hash      use argon2-cffi
+  when need stripe    use stripe-python
+  when need polar     use polar-python
+  when need lemon     use lemonsqueezy-py
 }

--- a/examples/airbnb/types.candy
+++ b/examples/airbnb/types.candy
@@ -1,0 +1,26 @@
+// types.candy — shared types and enums for the airbnb example.
+//
+// All cross-feature type names are defined here. Feature files reference
+// these by name; no import is needed (declarations resolve across files).
+
+type Id           opaque  { max: 64 }
+type Timestamp    instant { tz: utc }
+type Date         instant { tz: utc, precision: day }
+type DateRange    { from: Date, to: Date }
+type Email        string  { max: 320, format: rfc5322 }
+type Password     string  { policies: [PasswordStrength] }
+type PasswordHash opaque
+type Token        opaque  { max: 256 }
+type Key          opaque  { max: 128 }
+type Money        int     { unit: minor, currency: USD, round: nearest }
+type CouponCode   string  { max: 32 }
+
+type PaymentMethod opaque { max: 256 }
+type ChargeId      opaque { max: 128 }
+type RefundId      opaque { max: 128 }
+type TransferId    opaque { max: 128 }
+
+enum Role          { Guest, Host, Admin }
+enum BookingStatus { Pending, Confirmed, Cancelled, Completed }
+enum ListingStatus { Draft, Listed, Hidden }
+enum CouponKind    { Percent, FixedAmount }

--- a/examples/billing/README.md
+++ b/examples/billing/README.md
@@ -1,0 +1,239 @@
+# billing — recurring charges, retry-on-decline, and provider failover
+
+A subscription billing example. Customers subscribe to a plan; a
+scheduled job per active subscription attempts the monthly charge
+against an external payment provider. When a charge declines, the
+spec retries after 7 days; if it still fails after 21 days, the
+subscription is suspended (with a `SubscriptionSuspended` event) and
+the provider's charge is compensated. Multiple providers (Stripe,
+Polar, Lemon) are declared abstractly and selected per call.
+
+This example is the TIME-axis demonstration: it is the smallest
+self-contained spec that exercises `schedule`, `after`, and `until`
+together. Recurring billing is the canonical "deadline-driven async
+state machine" — the spec stays declarative while the substrate
+handles the wakeup.
+
+## What this exercises
+
+- **`schedule` keyword** — periodic charge job per active
+  subscription (GRAMMAR.md TIME axis).
+- **`after 7d` for retry delay** — failed charges schedule a retry
+  with an explicit delay (GRAMMAR.md "Time").
+- **`until` for escalation timeout** — retries continue until 21
+  days past the cycle, then escalate to suspension.
+- **`external actor Payments` with `providers: [Stripe, Polar,
+  Lemon]`** — abstract multi-provider declaration (GRAMMAR.md
+  "Multiple providers").
+- **`Actor[Tag]` selection in flows** — `Payments[Stripe]` at the
+  call site.
+- **Subscriber actor** — `Subscription` subscribes to `ChargeFailed`
+  webhook events to drive the state machine.
+- **Compensation on terminal failure** — suspended subscription
+  refunds any partial in-flight authorization.
+- **State enum with transitions** — `SubscriptionStatus { Active,
+  PastDue, Suspended, Cancelled }`.
+- **Audit trail** — every billing cycle appends to an audit on the
+  subscription.
+
+## Domain model
+
+### Types
+
+```
+type Id        opaque  { max: 64 }
+type Timestamp instant { tz: utc }
+type Key       opaque  { max: 128 }
+type Money     int     { unit: minor, currency: USD, round: nearest }
+type PlanId    opaque  { max: 64 }
+type ChargeId  opaque  { max: 64 }
+
+enum SubscriptionStatus { Active, PastDue, Suspended, Cancelled }
+
+type BillingCycle {
+  cycle:    int          // 0-indexed sequence number
+  amount:   Money
+  charge:   ChargeId?
+  outcome:  CycleOutcome
+  at:       Timestamp
+}
+
+enum CycleOutcome { Succeeded, Declined, Pending }
+```
+
+### Actors
+
+**Customer(id: Id)** — identified by `id`. State carries
+`email: Email`, `default_method: PaymentMethod`, and `created`. The
+external payment provider holds the source-of-truth payment method;
+the candy actor tracks only the reference.
+
+**Subscription(id: Id)** — identified by `id`. State:
+
+```
+state {
+  customer:    Id
+  plan:        PlanId
+  amount:      Money
+  status:      SubscriptionStatus = Active
+  period_end:  Timestamp
+  cycles:      [BillingCycle] = []
+  created:     Timestamp
+}
+```
+
+Invariants:
+
+- `period_end > created` (a subscription always covers a future
+  window at creation).
+- A subscription with `status == Cancelled` accepts no further
+  state transitions except `period_end` rollover to terminal.
+
+The Subscription subscribes to webhook events from `Payments`:
+
+```
+subscribe ChargeSucceeded -> RecordSuccess(charge)
+subscribe ChargeFailed    -> RecordFailure(charge, reason)
+```
+
+### Flows
+
+```
+flow Subscribe(customer: Id, plan: PlanId, amount: Money, key: Key, now: Timestamp)
+  -> Result<Id, InvalidPlan | PaymentMethodMissing>
+
+flow Cancel(subscription: Id, now: Timestamp)
+  -> Result<unit, AlreadyCancelled>
+
+flow ChargeCycle(subscription: Id, now: Timestamp, key: Key)
+  -> Result<BillingCycle, AlreadyCharged | SubscriptionInactive>
+
+flow RetryCharge(subscription: Id, originalCycle: int, now: Timestamp, key: Key)
+  -> Result<BillingCycle, EscalationTimeout>
+```
+
+- **`Subscribe`** validates the plan, checks the customer has a
+  payment method on file, sets `period_end = now after 30d`, and
+  emits `SubscriptionStarted`.
+- **`Cancel`** sets `status = Cancelled`, leaves `period_end`
+  intact (service runs through end of current period), emits
+  `SubscriptionCancelled`.
+- **`ChargeCycle`** is the scheduled-every-period flow. Calls
+  `Payments[Stripe].Charge(amount, customer.method, key)`. On
+  success, append a `Succeeded` cycle, advance `period_end` by 30d,
+  emit `SubscriptionCharged`. On decline, append a `Declined` cycle,
+  set `status = PastDue`, emit `SubscriptionPastDue`, and schedule
+  `RetryCharge` `after 7d`.
+- **`RetryCharge`** runs `until` 21d past the original cycle's
+  timestamp. On success, restore `status = Active`. On final
+  failure, set `status = Suspended`, emit `SubscriptionSuspended`,
+  and `compensate` any partial Stripe authorization with
+  `Payments.Refund`.
+
+### Schedule
+
+```
+schedule ChargeCycle(subscription, now, generate())
+  every 30d
+  for any subscription in Subscription where status == Active
+```
+
+The schedule entry lives in the spec next to the flow. Codegen wires
+it to the per-target queue (BullMQ for TS, Celery for Python, sqlc
++ cron for Go, axum + tokio for Rust).
+
+### Controllers
+
+| Method | Path                       | Target                                   | Auth   | Statuses                              |
+|--------|----------------------------|------------------------------------------|--------|---------------------------------------|
+| POST   | /subscriptions             | Subscribe(self, plan, amount, key, now)  | bearer | 201 / 422                             |
+| GET    | /subscriptions/:id         | Subscription(id)                         | bearer | 200 / 404                             |
+| DELETE | /subscriptions/:id         | Cancel(id, now)                          | bearer | 204 / 409 AlreadyCancelled            |
+| POST   | /webhooks/payments         | (dispatch to Payments emits)             | none   | 200 (signature-checked)               |
+
+The webhook route is the inbound side of the external actor — a
+provider POSTs `ChargeSucceeded` / `ChargeFailed` envelopes; the
+runtime validates the signature against the per-provider
+`webhook_secret` and dispatches to the subscribed actors.
+
+### Events
+
+```
+event SubscriptionStarted   { payload: { subscription: Id, customer: Id, plan: PlanId, at: Timestamp }, delivery: eager }
+event SubscriptionCharged   { payload: { subscription: Id, cycle: int, amount: Money, at: Timestamp }, delivery: eager }
+event SubscriptionPastDue   { payload: { subscription: Id, cycle: int, reason: string, at: Timestamp }, delivery: eager }
+event SubscriptionSuspended { payload: { subscription: Id, at: Timestamp }, delivery: strict }
+event SubscriptionCancelled { payload: { subscription: Id, at: Timestamp }, delivery: eager }
+```
+
+`SubscriptionSuspended` is `strict` (exactly-once) because downstream
+consumers (email notification, access revocation) must not double-fire.
+
+### Policies
+
+- **BillingAtomicity** — flow-scope on `ChargeCycle` and
+  `RetryCharge`. Asserts that the external charge result and the
+  Subscription status transition land together: either both apply or
+  the cycle is left in `Pending` for safe retry.
+
+### External dependencies
+
+**`external actor Payments` with `providers: [Stripe, Polar, Lemon]`.**
+
+Per-provider `config:` blocks declare `api_key` and `webhook_secret`
+secrets. The accepts/emits surface:
+
+```
+accepts Charge(amount: Money, method: PaymentMethod, key: Key)
+  -> Result<ChargeId, PaymentDeclined | NetworkError | RateLimited>
+
+accepts Refund(charge: ChargeId, amount: Money?)
+  -> Result<RefundId, RefundError | NetworkError>
+
+emits ChargeSucceeded { charge: ChargeId, at: Timestamp }
+emits ChargeFailed    { charge: ChargeId, reason: string, at: Timestamp }
+emits RefundProcessed { refund: RefundId, at: Timestamp }
+```
+
+This example uses `Payments[Stripe]` as the single live provider in
+flows; the `providers:` list is declared so that switching to Polar
+or Lemon (or running them in parallel for fallback) is a one-token
+edit at the call site, not a spec change.
+
+## Codegen targets
+
+All four targets supported. Per-target idioms:
+
+- **Go (chi)** — `stripe-go`; cron via `robfig/cron` or simple ticker
+  for `schedule`. Webhook route validates `Stripe-Signature`.
+- **Rust (axum)** — `async-stripe`; tokio cron for `schedule`. Webhook
+  validation via `stripe::Webhook::construct_event`.
+- **TypeScript (hono)** — `stripe-node`; BullMQ recurring jobs for
+  `schedule`. Webhook via `stripe.webhooks.constructEvent`.
+- **Python (fastapi)** — `stripe`; Celery beat for `schedule`. Webhook
+  via `stripe.Webhook.construct_event`.
+
+## Conformance
+
+Eval lives at `evals/billing/billing.hurl` (tracked by #28). Cover:
+
+- Happy path: subscribe → first cycle charges → 30d later, second
+  cycle charges → cancel → service continues until period_end.
+- Decline + recovery: cycle declines → status PastDue → retry after
+  7d succeeds → status returns to Active.
+- Escalation: cycle declines → all retries fail → 21d later, status
+  becomes Suspended and any in-flight charge is refunded.
+- Idempotency: re-firing a `ChargeCycle` with the same `key` returns
+  the prior cycle without double-charging.
+- Webhook race: out-of-order `ChargeSucceeded` and `ChargeFailed`
+  resolve to a deterministic terminal state.
+
+## Issue tracking
+
+- Implementation: #26
+- Eval: #28 (scaffold)
+
+## Status
+
+- [ ] Implementation pending
+- [ ] Eval pending

--- a/examples/billing/billing.candy
+++ b/examples/billing/billing.candy
@@ -1,0 +1,54 @@
+// billing.candy — TODO: implement per README.md scope.
+//
+// Scheduled recurring charges with retry-on-decline. Exercises the
+// TIME axis: schedule, after, until, plus compensation on terminal
+// failure (subscription suspension).
+
+prose {
+  intent: """
+    Recurring subscriptions billed against an external payment
+    provider. A scheduled job per active subscription attempts the
+    monthly charge; declines trigger a retry after 7d, escalating to
+    suspension if still failing after 21d. Providers (Stripe, Polar,
+    Lemon) are selected per call via Actor[Tag].
+  """
+
+  exports:
+    actor Subscription, Customer
+    flow  Subscribe, Cancel, ChargeCycle, RetryCharge
+    type  Money, PlanId, Key
+    event SubscriptionStarted, SubscriptionCharged,
+          SubscriptionPastDue, SubscriptionSuspended,
+          SubscriptionCancelled
+
+  uses:
+    external Payments for Charge, Refund
+
+  policies: [BillingAtomicity]
+}
+
+// TODO: types — Id, Timestamp, Key, Money (USD minor), PlanId,
+//       ChargeId, BillingCycle record.
+// TODO: enum SubscriptionStatus { Active, PastDue, Suspended,
+//       Cancelled }.
+// TODO: actor Customer — id, default payment method, billing email.
+// TODO: actor Subscription — id, customer, plan, status, period_end,
+//       audit of cycles; invariant: period_end > created.
+// TODO: external actor Payments with providers: [Stripe, Polar, Lemon];
+//       accepts Charge, Refund; emits ChargeSucceeded, ChargeFailed.
+// TODO: schedule ChargeCycle every period (monthly) per Active
+//       subscription.
+// TODO: flow Subscribe(customer, plan, key, now).
+// TODO: flow Cancel(subscription, now) — sets status = Cancelled at
+//       end of current period.
+// TODO: flow ChargeCycle(subscription, now, key) — Active path; on
+//       decline, schedule RetryCharge after 7d, emit
+//       SubscriptionPastDue, transition to PastDue.
+// TODO: flow RetryCharge(subscription, now, key) — runs after 7d
+//       until 21d after the original cycle; on terminal failure,
+//       compensate by suspending the subscription and emit
+//       SubscriptionSuspended.
+// TODO: policy BillingAtomicity — ensures charge result and
+//       subscription status transitions stay consistent.
+// TODO: events.
+// TODO: controller Billing with bearer-auth routes.

--- a/examples/billing/candy.toml
+++ b/examples/billing/candy.toml
@@ -1,0 +1,31 @@
+[project]
+name    = "billing"
+version = "0.1.0"
+
+[candy]
+runtime = "0.1"
+
+# Targets — where generated code goes. One subdirectory per target under targets/.
+[targets.go]
+language  = "go"
+framework = "chi"
+
+[targets.rust]
+language  = "rust"
+framework = "axum"
+
+[targets.typescript]
+language  = "typescript"
+framework = "hono"
+
+[targets.python]
+language  = "python"
+framework = "fastapi"
+
+# Runtime deps — prompts, skills, scripts. `candy install` (future) fetches these.
+[deps]
+"candy/grammar"      = "0.1"
+"candy/codegen-go"   = "0.1"
+"candy/codegen-rust" = "0.1"
+"candy/codegen-ts"   = "0.1"
+"candy/codegen-py"   = "0.1"

--- a/examples/billing/preferences.candy
+++ b/examples/billing/preferences.candy
@@ -1,0 +1,37 @@
+// preferences.candy — per-target library and idiom preferences for billing.
+// AI codegen consumes these as hints, not requirements.
+
+target go {
+  when need database  use sqlc
+  when need id        use ksuid
+  when need stripe    use stripe-go
+  when need polar     use polar-go
+  when need lemon     use lemonsqueezy-go
+}
+
+target rust {
+  when need database  use sqlx
+  when need id        use uuid-v7
+  when need stripe    use async-stripe
+  when need polar     use polar-rust
+  when need lemon     use lemonsqueezy-rust
+}
+
+target typescript {
+  notes: "ESM only; tagged unions over class hierarchies"
+  when need queue     use bullmq
+  when need id        use cuid2
+  when need database  use drizzle
+  when need stripe    use stripe-node
+  when need polar     use polar-sdk
+  when need lemon     use lemonsqueezy-node
+}
+
+target python {
+  when need queue     use celery
+  when need id        use ulid
+  when need database  use sqlalchemy
+  when need stripe    use stripe
+  when need polar     use polar-sdk
+  when need lemon     use lemonsqueezy-py
+}

--- a/examples/notifications/README.md
+++ b/examples/notifications/README.md
@@ -1,0 +1,214 @@
+# notifications — event-driven fan-out to email and SMS
+
+A NotificationWorker actor subscribes to internal events
+(`UserSignedUp`, `OrderShipped`) and dispatches user-facing
+notifications via external providers. Email goes through one of
+SendGrid, Mailgun, or Resend; SMS goes through Twilio or Vonage.
+Provider selection happens at the call site with `Actor[Tag]`.
+Failures retry with exponential backoff and emit
+`NotificationFailed` if the retry budget is exhausted.
+
+This is the smallest spec that exercises `subscribe`, multi-provider
+external actors, and a fan-out pipeline together. The point is to
+show the asynchronous edge of the system — the side where work is
+*pulled* by subscribers rather than *pushed* by a controller.
+
+## What this exercises
+
+- **`subscribe` to internal events** — `NotificationWorker`
+  subscribes to `UserSignedUp` and `OrderShipped`, both declared as
+  `uses:` imports in the prose block (GRAMMAR.md "event",
+  "subscribe").
+- **`external actor` with `providers:` for Email and SMS** — two
+  separate external actors, each with its own provider set
+  (GRAMMAR.md "Multiple providers").
+- **`Actor[Tag]` selection in flows** — `Email[SendGrid]`,
+  `SMS[Twilio]`.
+- **Fan-out pattern** — one source event triggers multiple delivery
+  attempts across channels.
+- **Retry-on-failure via re-emit** — a delivery failure emits a
+  delayed retry envelope rather than blocking; subscribers handle
+  retries asynchronously.
+- **Delivery-status events** — `NotificationSent` and
+  `NotificationFailed` for downstream observability.
+- **Idempotency** — every `Send` carries a `key: Key` derived from
+  the source event id, so re-delivery does not duplicate.
+
+## Domain model
+
+### Types
+
+```
+type Id           opaque  { max: 64 }
+type Timestamp    instant { tz: utc }
+type Key          opaque  { max: 128 }
+type EmailAddress string  { max: 320, format: rfc5322 }
+type PhoneNumber  string  { max: 20,  format: e164 }
+type MessageId    opaque  { max: 128 }    // provider-side id
+
+enum NotificationKind { Welcome, Shipped }
+enum Channel          { EmailChannel, SMSChannel }
+enum AttemptOutcome   { Delivered, TransientFailure, PermanentFailure }
+
+type DeliveryAttempt {
+  attempt:     int
+  channel:     Channel
+  provider:    string         // "sendgrid" | "twilio" | etc.
+  message:     MessageId?
+  outcome:     AttemptOutcome
+  reason:      string?
+  at:          Timestamp
+}
+```
+
+### Actors
+
+**NotificationWorker(id: Id)** — singleton-ish actor (one instance
+per region or shard). Stateful only enough to dedup recently-handled
+event keys and track attempt counts. Subscribes:
+
+```
+subscribe UserSignedUp -> Send(payload.user, Welcome, EmailChannel, payload.user, now)
+subscribe OrderShipped -> Send(payload.user, Shipped, EmailChannel, payload.order, now)
+subscribe OrderShipped -> Send(payload.user, Shipped, SMSChannel,   payload.order, now)
+```
+
+The `key` argument to `Send` is derived from the source event id so
+that any re-delivery of the source event collapses to a single
+notification.
+
+State:
+
+```
+state {
+  recent: [DeliveryAttempt] = []   // bounded ring; drop oldest beyond N
+}
+```
+
+Invariants: `length(recent) <= 1000` (a soft guard — true persistence
+lives in the database; this is a read-through cache for dedup).
+
+### Flows
+
+```
+flow Send(recipient: Id, kind: NotificationKind, channel: Channel,
+          key: Key, now: Timestamp)
+  -> Result<DeliveryAttempt, RecipientUnreachable | NoContactInfo>
+
+flow Retry(prior: DeliveryAttempt, now: Timestamp, key: Key)
+  -> Result<DeliveryAttempt, RetryBudgetExhausted>
+```
+
+- **`Send`** looks up the recipient's contact info, picks a provider
+  via `Actor[Tag]` (default `Email[SendGrid]` or `SMS[Twilio]`),
+  calls `SendEmail` or `SendSMS`, and emits `NotificationSent` on
+  success. Transient failures emit a delayed retry envelope (handled
+  by `Retry` after `30s`, then `2m`, then `10m`).
+- **`Retry`** re-attempts with exponential backoff up to a
+  configurable `MaxAttempts` (default 3). Terminal failure emits
+  `NotificationFailed`.
+
+### Controllers
+
+| Method | Path                          | Target                                       | Auth   | Statuses                          |
+|--------|-------------------------------|----------------------------------------------|--------|-----------------------------------|
+| POST   | /admin/notifications/test     | Send(recipient, kind, channel, generate(), now) | bearer | 202 / 422                         |
+| POST   | /admin/notifications/replay   | Retry(attempt, now, generate())              | bearer | 202 / 409 RetryBudgetExhausted    |
+| POST   | /webhooks/email               | (dispatch to Email emits)                    | none   | 200 (signature-checked)           |
+| POST   | /webhooks/sms                 | (dispatch to SMS emits)                      | none   | 200 (signature-checked)           |
+
+The two webhook routes are the inbound side of the external actors —
+SendGrid/Mailgun/Resend POST delivery-status events; Twilio/Vonage
+POST SMS status. Subscribers (here, `NotificationWorker`) react.
+
+The bulk of the work happens via `subscribe`, not via these routes.
+Controllers exist for admin testing and replay only.
+
+### Events
+
+Internal events imported via `uses:` (declared in the features that
+emit them, not here):
+
+```
+event UserSignedUp { payload: { user: Id, email: EmailAddress, at: Timestamp }, delivery: eager }
+event OrderShipped { payload: { user: Id, order: Id, at: Timestamp },           delivery: eager }
+```
+
+Events emitted by this feature:
+
+```
+event NotificationSent   { payload: { recipient: Id, kind: NotificationKind, channel: Channel, provider: string, message: MessageId, at: Timestamp }, delivery: eager }
+event NotificationFailed { payload: { recipient: Id, kind: NotificationKind, channel: Channel, attempts: int, reason: string, at: Timestamp }, delivery: strict }
+```
+
+`NotificationFailed` is `strict` (exactly-once) because it likely
+triggers an alert or compensation upstream.
+
+### Policies
+
+- **DeliveryAtLeastOnce** — feature-scope. Asserts that every source
+  event handled by `NotificationWorker` results in either a
+  `NotificationSent` or a `NotificationFailed`. No silent drops.
+
+### External dependencies
+
+**`external actor Email` with `providers: [SendGrid, Mailgun, Resend]`.**
+
+```
+accepts SendEmail(to: EmailAddress, subject: string, body: string, key: Key)
+  -> Result<MessageId, EmailRejected | NetworkError | RateLimited>
+
+emits EmailDelivered { message: MessageId, at: Timestamp }
+emits EmailBounced   { message: MessageId, reason: string, at: Timestamp }
+```
+
+**`external actor SMS` with `providers: [Twilio, Vonage]`.**
+
+```
+accepts SendSMS(to: PhoneNumber, body: string, key: Key)
+  -> Result<MessageId, SMSRejected | NetworkError | RateLimited>
+
+emits SMSDelivered { message: MessageId, at: Timestamp }
+emits SMSFailed    { message: MessageId, reason: string, at: Timestamp }
+```
+
+Per-provider `config:` blocks declare API keys and webhook secrets.
+
+## Codegen targets
+
+All four targets supported. Per-target idioms:
+
+- **Go (chi)** — providers via their official Go SDKs; channels +
+  goroutines for the retry pipeline. Webhook routes per provider.
+- **Rust (axum)** — provider clients behind a trait; tokio tasks for
+  the retry pipeline.
+- **TypeScript (hono)** — BullMQ for the retry queue; per-provider
+  Node SDKs.
+- **Python (fastapi)** — Celery for the retry queue; per-provider
+  Python SDKs.
+
+## Conformance
+
+Eval lives at `evals/notifications/notifications.hurl` (tracked by
+#28). Cover:
+
+- Happy path: `UserSignedUp` → `NotificationSent` (email).
+- Fan-out: `OrderShipped` → both an email and an SMS notification.
+- Retry: simulated transient `NetworkError` retries up to budget,
+  succeeds on attempt 2, emits `NotificationSent`.
+- Permanent failure: `EmailRejected` exhausts retry budget, emits
+  `NotificationFailed`.
+- Idempotency: re-delivering the same source event with the same
+  derived key does not duplicate the notification.
+- Webhook integration: a provider POSTs `EmailDelivered` →
+  `NotificationWorker` reconciles attempt state.
+
+## Issue tracking
+
+- Implementation: #27
+- Eval: #28 (scaffold)
+
+## Status
+
+- [ ] Implementation pending
+- [ ] Eval pending

--- a/examples/notifications/candy.toml
+++ b/examples/notifications/candy.toml
@@ -1,0 +1,31 @@
+[project]
+name    = "notifications"
+version = "0.1.0"
+
+[candy]
+runtime = "0.1"
+
+# Targets — where generated code goes. One subdirectory per target under targets/.
+[targets.go]
+language  = "go"
+framework = "chi"
+
+[targets.rust]
+language  = "rust"
+framework = "axum"
+
+[targets.typescript]
+language  = "typescript"
+framework = "hono"
+
+[targets.python]
+language  = "python"
+framework = "fastapi"
+
+# Runtime deps — prompts, skills, scripts. `candy install` (future) fetches these.
+[deps]
+"candy/grammar"      = "0.1"
+"candy/codegen-go"   = "0.1"
+"candy/codegen-rust" = "0.1"
+"candy/codegen-ts"   = "0.1"
+"candy/codegen-py"   = "0.1"

--- a/examples/notifications/notifications.candy
+++ b/examples/notifications/notifications.candy
@@ -1,0 +1,47 @@
+// notifications.candy — TODO: implement per README.md scope.
+//
+// Event-driven async pipeline: a NotificationWorker subscribes to
+// internal events (UserSignedUp, OrderShipped) and fans them out to
+// email and SMS providers. Smallest exercise of subscribe + external
+// + retry-on-failure via re-emit.
+
+prose {
+  intent: """
+    Fan-out delivery of internal events to user-facing channels.
+    A NotificationWorker actor subscribes to UserSignedUp and
+    OrderShipped, looks up the user's contact preferences, and
+    dispatches to Email and/or SMS providers. Failures re-emit a
+    delayed retry envelope; permanent failures emit
+    NotificationFailed for downstream observability.
+  """
+
+  exports:
+    actor NotificationWorker
+    flow  Send, Retry
+    event NotificationSent, NotificationFailed
+
+  uses:
+    external Email for SendEmail
+    external SMS   for SendSMS
+
+  policies: [DeliveryAtLeastOnce]
+}
+
+// TODO: types — Id, Timestamp, Key, EmailAddress, PhoneNumber,
+//       NotificationKind enum (Welcome, Shipped), Channel enum
+//       (EmailChannel, SMSChannel), DeliveryAttempt record.
+// TODO: actor NotificationWorker — subscribes to UserSignedUp,
+//       OrderShipped (declared in uses); minimal state (recent
+//       attempts, dedup keys).
+// TODO: external actor Email with providers: [SendGrid, Mailgun,
+//       Resend]; accepts SendEmail; emits EmailDelivered, EmailBounced.
+// TODO: external actor SMS with providers: [Twilio, Vonage];
+//       accepts SendSMS; emits SMSDelivered, SMSFailed.
+// TODO: flow Send(recipient, kind, channel, key, now) — picks a
+//       provider via Actor[Tag] and dispatches.
+// TODO: flow Retry(attempt, now, key) — re-emits with exponential
+//       backoff up to MaxAttempts; on terminal failure emits
+//       NotificationFailed.
+// TODO: events NotificationSent, NotificationFailed.
+// TODO: policy DeliveryAtLeastOnce — feature-scope.
+// TODO: controller Notifications (admin-only test/replay routes).

--- a/examples/notifications/preferences.candy
+++ b/examples/notifications/preferences.candy
@@ -1,0 +1,45 @@
+// preferences.candy — per-target library and idiom preferences for notifications.
+// AI codegen consumes these as hints, not requirements.
+
+target go {
+  when need database  use sqlc
+  when need id        use ksuid
+  when need sendgrid  use sendgrid-go
+  when need mailgun   use mailgun-go
+  when need resend    use resend-go
+  when need twilio    use twilio-go
+  when need vonage    use vonage-go
+}
+
+target rust {
+  when need database  use sqlx
+  when need id        use uuid-v7
+  when need sendgrid  use sendgrid-rs
+  when need mailgun   use mailgun-rs
+  when need resend    use resend-rs
+  when need twilio    use twilio-rs
+  when need vonage    use vonage-rs
+}
+
+target typescript {
+  notes: "ESM only; tagged unions over class hierarchies"
+  when need queue     use bullmq
+  when need id        use cuid2
+  when need database  use drizzle
+  when need sendgrid  use sendgrid-node
+  when need mailgun   use mailgun-js
+  when need resend    use resend-node
+  when need twilio    use twilio-node
+  when need vonage    use vonage-node
+}
+
+target python {
+  when need queue     use celery
+  when need id        use ulid
+  when need database  use sqlalchemy
+  when need sendgrid  use sendgrid-python
+  when need mailgun   use mailgun-py
+  when need resend    use resend-py
+  when need twilio    use twilio-python
+  when need vonage    use vonage-python
+}

--- a/examples/rbac/README.md
+++ b/examples/rbac/README.md
@@ -1,0 +1,183 @@
+# rbac — role-based access control via a swappable external library
+
+A small access-control example. Users are granted roles; roles carry
+permissions over Resources. Authorization decisions are delegated to a
+third-party RBAC library — Casbin, Oso, or Casl — and the candy spec
+declares the contract abstractly so the library is one preference edit
+away from being swapped. The interesting property: the policy data lives
+in candy actors; the policy *evaluation* lives in the external library.
+
+This is the canonical demonstration of `external actor` with
+`providers:` and the `Actor[Tag]` selector — the smallest spec that
+exercises the multi-provider grammar end to end.
+
+## What this exercises
+
+- **`external actor` with `providers:`** — three named providers
+  (Casbin, Oso, Casl) declared in one block (GRAMMAR.md "Multiple
+  providers").
+- **`Actor[Tag]` selector at call sites** — flows pick a provider per
+  call (GRAMMAR.md "Multiple providers").
+- **`prose` block with `uses:`** — declares the external dependency and
+  the specific operations consumed (GRAMMAR.md "prose").
+- **Policy attachment at controller scope and route scope** — admin-only
+  routes gated by `RoleGated` (GRAMMAR.md "Policy attachment").
+- **Resource actor with state** — Resources are owned by Users; the spec
+  models ownership and creation.
+- **Audit on User** — every grant and revoke appends to an
+  append-only audit list (GRAMMAR.md `audit`).
+- **Idempotency** — `Grant` and `Revoke` accept `key: Key` so replays
+  are safe.
+
+## Domain model
+
+### Types
+
+```
+type Id            opaque  { max: 64 }
+type Timestamp     instant { tz: utc }
+type Key           opaque  { max: 128 }
+type ResourceId    opaque  { max: 64 }
+type ResourceKind  string  { max: 64 }    // e.g. "document", "project"
+
+enum Role        { Admin, Editor, Viewer }
+enum Permission  { Read, Write, Delete, Share }
+enum Action      { Read, Write, Delete, Share }
+```
+
+### Actors
+
+**User(id: Id)** — identified by `id`. State carries the set of
+`Role`s currently assigned to the user and the user's `created`
+timestamp. Audit log records every grant and revoke (subject, role,
+actor that performed the change, timestamp). Invariant: a user holds
+each role at most once.
+
+**Resource(id: ResourceId)** — identified by `id`. State carries
+`owner: Id`, `kind: ResourceKind`, and `created: Timestamp`. The
+resource's owner is implicitly granted full permissions; the external
+RBAC library is the source of truth for everyone else. Invariant:
+`owner` is set at creation and never changes.
+
+### Flows
+
+```
+flow Grant(target: Id, role: Role, now: Timestamp, key: Key)
+  -> Result<unit, AlreadyGranted | NotAuthorized>
+
+flow Revoke(target: Id, role: Role, now: Timestamp, key: Key)
+  -> Result<unit, NotGranted | NotAuthorized>
+
+flow Check(subject: Id, action: Action, resource: ResourceId)
+  -> Result<Allowed, Denied>
+
+flow CreateResource(owner: Id, kind: ResourceKind, now: Timestamp, key: Key)
+  -> Result<ResourceId, InvalidKind>
+```
+
+- `Grant` and `Revoke` are admin-only (enforced by `RoleGated` on the
+  route). Both update the User actor's role set, push to the audit log,
+  and call `RBAC[Casbin].AddPolicy` / `RemovePolicy` to keep the
+  external policy store in sync. Both are idempotent on `key`.
+- `Check` is a fast-path read. Resolves owner-implicit permission first;
+  on miss, calls `RBAC[Casbin].Enforce(subject, action, resource)` and
+  emits `AccessChecked`.
+- `CreateResource` mints a new `ResourceId`, persists ownership, and
+  registers the owner-implicit policy with the external library.
+
+### Controllers
+
+| Method  | Path                    | Target                                  | Auth     | Statuses                                    |
+|---------|-------------------------|-----------------------------------------|----------|---------------------------------------------|
+| POST    | /resources              | CreateResource(self, kind, now, key)    | bearer   | 201 / 422 InvalidKind                       |
+| POST    | /users/:id/roles        | Grant(id, role, now, key)               | bearer + RoleGated(Admin) | 204 / 409 AlreadyGranted / 403 NotAuthorized |
+| DELETE  | /users/:id/roles/:role  | Revoke(id, role, now, key)              | bearer + RoleGated(Admin) | 204 / 404 NotGranted / 403 NotAuthorized     |
+| GET     | /check                  | Check(self, action, resource)           | bearer   | 200 { allowed: bool } / 403 Denied          |
+
+The `RoleGated(Admin)` route-scope policy runs before dispatch and
+rejects callers who do not hold the `Admin` role.
+
+### Events
+
+```
+event RoleGranted   { payload: { actor: Id, target: Id, role: Role, at: Timestamp }, delivery: eager }
+event RoleRevoked   { payload: { actor: Id, target: Id, role: Role, at: Timestamp }, delivery: eager }
+event AccessChecked { payload: { subject: Id, action: Action, resource: ResourceId, allowed: bool, at: Timestamp }, delivery: eager }
+```
+
+`AccessChecked` is high-volume; subscribers are expected to sample
+or batch.
+
+### Policies
+
+- **RoleGated** — feature-scope policy declared in the `prose` block
+  and attached at the route scope on admin-only routes. Takes a required
+  role; rejects callers who do not hold it. Examples cover Admin,
+  Editor, and Viewer cases.
+
+### External dependencies
+
+**`external actor RBAC` with `providers: [Casbin, Oso, Casl]`.**
+
+Each provider has its own `config:` block (model file path, policy
+store URL, or API key depending on provider). The accepts surface is:
+
+```
+accepts Enforce(subject: Id, action: Action, object: ResourceId)
+  -> Result<bool, RBACError>
+
+accepts AddPolicy(subject: Id, role: Role, object: ResourceId?)
+  -> Result<unit, RBACError>
+
+accepts RemovePolicy(subject: Id, role: Role, object: ResourceId?)
+  -> Result<unit, RBACError>
+```
+
+No `emits` — RBAC libraries are synchronous decision engines, not event
+sources.
+
+Provider selection in this example uses `RBAC[Casbin]` everywhere; the
+point is that swapping to `RBAC[Oso]` is a one-token edit. A real
+deployment that wanted live failover would use the rescue chain pattern
+shown in GRAMMAR.md.
+
+**Cross-target portability note.** `Casl` is JavaScript-only and is bound
+only on the TypeScript target in `preferences.candy`. Calls that go
+through `RBAC[Casl]` from Go/Rust/Python will fail at codegen time. Pick
+`Casbin` or `Oso` for portable code paths; reserve `Casl` for TS-specific
+flows.
+
+## Codegen targets
+
+All four targets supported. Per-target idioms:
+
+- **Go (chi)** — Casbin via `casbin-go`; route middleware enforces
+  `RoleGated`.
+- **Rust (axum)** — Casbin via `casbin-rs`; tower layer for `RoleGated`.
+- **TypeScript (hono)** — Casl as the abstract layer; hono middleware
+  for `RoleGated`.
+- **Python (fastapi)** — Casbin Python; FastAPI dependency for
+  `RoleGated`.
+
+## Conformance
+
+Eval lives at `evals/rbac/rbac.hurl` (tracked by #28). Cover:
+
+- Happy path: admin grants Editor → user can write a resource → admin
+  revokes → user cannot write.
+- Owner shortcut: resource owner can always read/write/delete their own
+  resource without an explicit grant.
+- Authorization: non-admin attempts to grant → 403.
+- Idempotency: same `key` on `Grant` returns the same result without
+  double-applying.
+- Audit: every grant/revoke appears in the User's audit log.
+
+## Issue tracking
+
+- Implementation: #25
+- Eval: #28 (scaffold)
+
+## Status
+
+- [ ] Implementation pending
+- [ ] Eval pending

--- a/examples/rbac/candy.toml
+++ b/examples/rbac/candy.toml
@@ -1,0 +1,31 @@
+[project]
+name    = "rbac"
+version = "0.1.0"
+
+[candy]
+runtime = "0.1"
+
+# Targets — where generated code goes. One subdirectory per target under targets/.
+[targets.go]
+language  = "go"
+framework = "chi"
+
+[targets.rust]
+language  = "rust"
+framework = "axum"
+
+[targets.typescript]
+language  = "typescript"
+framework = "hono"
+
+[targets.python]
+language  = "python"
+framework = "fastapi"
+
+# Runtime deps — prompts, skills, scripts. `candy install` (future) fetches these.
+[deps]
+"candy/grammar"      = "0.1"
+"candy/codegen-go"   = "0.1"
+"candy/codegen-rust" = "0.1"
+"candy/codegen-ts"   = "0.1"
+"candy/codegen-py"   = "0.1"

--- a/examples/rbac/preferences.candy
+++ b/examples/rbac/preferences.candy
@@ -1,0 +1,36 @@
+// preferences.candy — per-target library and idiom preferences for rbac.
+// AI codegen consumes these as hints, not requirements.
+//
+// Note: `casl` is JavaScript-only. On Go/Rust/Python it is intentionally
+// unbound; codegen errors clearly if a flow tries `RBAC[Casl]` on those
+// targets. Pick `Casbin` or `Oso` instead for cross-target portability.
+
+target go {
+  when need database  use sqlc
+  when need id        use ksuid
+  when need casbin    use casbin-go
+  when need oso       use oso-go
+}
+
+target rust {
+  when need database  use sqlx
+  when need id        use uuid-v7
+  when need casbin    use casbin-rs
+  when need oso       use oso
+}
+
+target typescript {
+  notes: "ESM only; tagged unions over class hierarchies"
+  when need id        use cuid2
+  when need database  use drizzle
+  when need casbin    use node-casbin
+  when need oso       use oso-cloud
+  when need casl      use casl-ability
+}
+
+target python {
+  when need id        use ulid
+  when need database  use sqlalchemy
+  when need casbin    use casbin
+  when need oso       use oso
+}

--- a/examples/rbac/rbac.candy
+++ b/examples/rbac/rbac.candy
@@ -1,0 +1,40 @@
+// rbac.candy — TODO: implement per README.md scope.
+//
+// Role-based access control delegated to an external library.
+// Demonstrates abstract external actor with multiple providers
+// (Casbin, Oso, Casl), Actor[Tag] selection at call sites, and
+// controller-scoped policy attachment for role-gated routes.
+
+prose {
+  intent: """
+    Role-based access control over Resources, owned by Users.
+    Authorization decisions are delegated to a swappable external
+    RBAC library — Casbin, Oso, or Casl — selected per call via
+    Actor[Tag]. The candy spec owns the role/permission model and
+    the audit story; the library owns the policy evaluation.
+  """
+
+  exports:
+    actor User, Resource
+    flow  Grant, Revoke, Check, CreateResource
+    type  Role, Permission, ResourceId
+    event RoleGranted, RoleRevoked, AccessChecked
+
+  uses:
+    external RBAC for Enforce, AddPolicy, RemovePolicy
+
+  policies: [RoleGated]
+}
+
+// TODO: types — Id, Timestamp, Key, Role enum, Permission enum, ResourceId.
+// TODO: actor User — id, role assignments, audit of grants/revokes.
+// TODO: actor Resource — id, owner, kind, created.
+// TODO: external actor RBAC with providers: [Casbin, Oso, Casl];
+//       accepts Enforce(subject, action, object), AddPolicy, RemovePolicy.
+// TODO: policy RoleGated — feature-scope; rejects unauthorized callers.
+// TODO: flow Grant(user, role, now, key) — admin grants a role to a user.
+// TODO: flow Revoke(user, role, now, key) — admin revokes a role.
+// TODO: flow Check(subject, action, resource) -> Result<Allowed, Denied>.
+// TODO: flow CreateResource(owner, kind, now, key).
+// TODO: events RoleGranted, RoleRevoked, AccessChecked.
+// TODO: controller RBAC with role-gated routes (admin-only Grant/Revoke).

--- a/examples/wallet/README.md
+++ b/examples/wallet/README.md
@@ -1,0 +1,176 @@
+# wallet — money primitives, idempotency, and conservation invariants
+
+A per-user wallet supporting topup, withdraw, and peer-to-peer transfer.
+Money is integer minor units in USD; floats are forbidden by the
+language. Every state change appends a journal entry, and the wallet's
+balance is *derived* from the journal — there is no second copy of the
+truth. Replays are safe: every flow accepts an idempotency `key`.
+
+This is a pure in-spec example: no external payment SDKs, no providers,
+no schedules. The interesting properties are the two-party transfer
+saga, the journal-as-source-of-truth pattern, and the conservation
+invariants that make double-spend bugs expressible as predicates.
+
+## What this exercises
+
+- **Branded `Money` type** — `int { unit: minor, currency: USD,
+  round: nearest }` (GRAMMAR.md "type").
+- **Append-only journal in actor state** — `journal: [JournalEntry]`
+  with derived balance (GRAMMAR.md `derive`).
+- **Predicate invariants** — `balance >= 0` and
+  `balance == sum(journal.delta)` (GRAMMAR.md "invariant").
+- **Idempotency keys** — `key: Key` on every replayable message and
+  flow (GRAMMAR.md "Cross-cutting conventions").
+- **Flow-scope policy attachment** — `TransferAtomicity` on `Transfer`
+  (GRAMMAR.md "Policy attachment").
+- **Saga compensation** — `Transfer` debits source, then credits
+  destination; if the credit fails, the debit compensates.
+- **Multi-actor flow** — `Transfer` touches two `Wallet` instances.
+
+## Domain model
+
+### Types
+
+```
+type Id        opaque  { max: 64 }
+type Timestamp instant { tz: utc }
+type Key       opaque  { max: 128 }
+type Money     int     { unit: minor, currency: USD, round: nearest }
+
+enum EntryKind { Topup, Withdrawal, TransferOut, TransferIn }
+
+type JournalEntry {
+  id:          Id
+  kind:        EntryKind
+  delta:       Money     // positive for credits, negative for debits
+  counterpart: Id?       // peer wallet id for transfers
+  key:         Key       // idempotency key for the originating flow
+  at:          Timestamp
+}
+```
+
+### Actors
+
+**Wallet(id: Id)** — identified by `id`. State carries `owner: Id`,
+`journal: [JournalEntry]`, and `created: Timestamp`. The balance is
+*not* stored — it is `derive balance = sum(journal.delta)`. Two
+invariants:
+
+```
+invariant balance >= 0
+invariant balance == sum(journal.delta)
+```
+
+The second invariant is technically tautological by construction, but
+declaring it makes the intent explicit and gives codegen a hook to
+generate a self-check on every read in debug builds.
+
+Accepts:
+
+```
+accepts Credit(amount: Money, kind: EntryKind, counterpart: Id?, key: Key, now: Timestamp)
+  -> Result<JournalEntry, ReplayMismatch>
+
+accepts Debit(amount: Money, kind: EntryKind, counterpart: Id?, key: Key, now: Timestamp)
+  -> Result<JournalEntry, InsufficientFunds | ReplayMismatch>
+```
+
+Both are idempotent on `key`: replaying with the same key returns the
+prior journal entry. `ReplayMismatch` covers the case where the same key
+arrives with different parameters (a programming error in the caller).
+
+### Flows
+
+```
+flow Topup(wallet: Id, amount: Money, key: Key, now: Timestamp)
+  -> Result<JournalEntry, InvalidAmount>
+
+flow Withdraw(wallet: Id, amount: Money, key: Key, now: Timestamp)
+  -> Result<JournalEntry, InsufficientFunds | InvalidAmount>
+
+flow Transfer(from: Id, to: Id, amount: Money, key: Key, now: Timestamp)
+  -> Result<{ debit: JournalEntry, credit: JournalEntry },
+            InsufficientFunds | InvalidAmount | SelfTransfer>
+```
+
+`Transfer` is the saga: debit the source wallet, then credit the
+destination. If the credit fails for any reason, compensate the source
+debit by issuing a reversing credit with a derived key. The
+`TransferAtomicity` policy is attached at flow scope and asserts the
+two-leg-or-zero-legs property.
+
+### Controllers
+
+| Method | Path                   | Target                                  | Auth   | Statuses                         |
+|--------|------------------------|-----------------------------------------|--------|----------------------------------|
+| GET    | /wallets/:id           | Wallet(id).balance                      | bearer | 200 / 404                        |
+| GET    | /wallets/:id/journal   | Wallet(id).journal                      | bearer | 200                              |
+| POST   | /wallets/:id/topup     | Topup(id, amount, key, now)             | bearer | 201 / 422 InvalidAmount          |
+| POST   | /wallets/:id/withdraw  | Withdraw(id, amount, key, now)          | bearer | 201 / 422 / 409 InsufficientFunds|
+| POST   | /transfers             | Transfer(from, to, amount, key, now)    | bearer | 201 / 422 / 409 / 422 SelfTransfer|
+
+Bearer auth scopes reads and writes to the authenticated wallet owner.
+Cross-owner reads are out of scope for this example.
+
+### Events
+
+```
+event WalletTopped       { payload: { wallet: Id, amount: Money, at: Timestamp }, delivery: eager }
+event WalletWithdrawn    { payload: { wallet: Id, amount: Money, at: Timestamp }, delivery: eager }
+event WalletTransferred  { payload: { from: Id, to: Id, amount: Money, at: Timestamp }, delivery: eager }
+```
+
+All three are `eager` — at-least-once delivery. Subscribers must be
+idempotent on the entry id.
+
+### Policies
+
+- **TransferAtomicity** — flow-scope on `Transfer`. Prose: a transfer
+  either commits both legs or neither, regardless of failure mode.
+  Examples cover (a) successful round-trip, (b) credit-fails-after-debit
+  triggers compensation, (c) replay with same key returns the same
+  result without double-applying, (d) self-transfer rejects with
+  `SelfTransfer` before any state change.
+
+### External dependencies
+
+None. This example is intentionally substrate-only — `id` and
+`database` from `preferences.candy`. The pedagogical point is that
+non-trivial financial logic does not require an external SDK.
+
+## Codegen targets
+
+All four targets supported. Per-target idioms:
+
+- **Go (chi)** — `Money` as `int64`; sqlc-generated journal queries.
+- **Rust (axum)** — `Money` as `i64` newtype with arithmetic methods;
+  `sqlx` transactions for the `Transfer` saga.
+- **TypeScript (hono)** — `Money` as `bigint` (avoid Number for cents
+  past 2^53); drizzle for the journal table.
+- **Python (fastapi)** — `Money` as `int`; `sqlalchemy` Session for
+  per-flow transactions.
+
+## Conformance
+
+Eval lives at `evals/wallet/wallet.hurl` (tracked by #28). Cover:
+
+- Happy path: topup → withdraw → transfer → balances reconcile.
+- Conservation: derived balance equals `sum(journal.delta)` after every
+  operation.
+- Insufficient funds: withdraw above balance returns 409 and does not
+  append a journal entry.
+- Self-transfer: rejects with `SelfTransfer` and does not touch state.
+- Idempotency: replaying topup/withdraw/transfer with the same `key`
+  returns the prior result; balance does not double-move.
+- Atomicity: simulated credit failure on transfer leaves both wallets
+  at their pre-transfer balance.
+
+## Issue tracking
+
+- Implementation: #6
+- Eval: #28 (scaffold)
+
+## Status
+
+- [ ] Implementation pending
+- [ ] Eval pending

--- a/examples/wallet/candy.toml
+++ b/examples/wallet/candy.toml
@@ -1,0 +1,31 @@
+[project]
+name    = "wallet"
+version = "0.1.0"
+
+[candy]
+runtime = "0.1"
+
+# Targets — where generated code goes. One subdirectory per target under targets/.
+[targets.go]
+language  = "go"
+framework = "chi"
+
+[targets.rust]
+language  = "rust"
+framework = "axum"
+
+[targets.typescript]
+language  = "typescript"
+framework = "hono"
+
+[targets.python]
+language  = "python"
+framework = "fastapi"
+
+# Runtime deps — prompts, skills, scripts. `candy install` (future) fetches these.
+[deps]
+"candy/grammar"      = "0.1"
+"candy/codegen-go"   = "0.1"
+"candy/codegen-rust" = "0.1"
+"candy/codegen-ts"   = "0.1"
+"candy/codegen-py"   = "0.1"

--- a/examples/wallet/preferences.candy
+++ b/examples/wallet/preferences.candy
@@ -1,0 +1,23 @@
+// preferences.candy — per-target library and idiom preferences for wallet.
+// AI codegen consumes these as hints, not requirements.
+
+target go {
+  when need database  use sqlc
+  when need id        use ksuid
+}
+
+target rust {
+  when need database  use sqlx
+  when need id        use uuid-v7
+}
+
+target typescript {
+  notes: "ESM only; tagged unions over class hierarchies"
+  when need id        use cuid2
+  when need database  use drizzle
+}
+
+target python {
+  when need id        use ulid
+  when need database  use sqlalchemy
+}

--- a/examples/wallet/wallet.candy
+++ b/examples/wallet/wallet.candy
@@ -1,0 +1,37 @@
+// wallet.candy — TODO: implement per README.md scope.
+//
+// Money primitives with idempotency, append-only journal, and
+// conservation invariants. No external SDKs — pure in-spec accounting.
+
+prose {
+  intent: """
+    A per-user wallet with topup, withdraw, and transfer flows.
+    Money is integer minor units in USD. Every state change appends
+    a journal entry; balance is derived from the journal so the two
+    cannot disagree. Replays are idempotent on key.
+  """
+
+  exports:
+    actor Wallet
+    flow  Topup, Withdraw, Transfer
+    type  Money, Key
+    event WalletTopped, WalletWithdrawn, WalletTransferred
+
+  policies: [TransferAtomicity]
+}
+
+// TODO: types — Id, Timestamp, Key, Money (unit: minor, currency: USD,
+//       round: nearest), JournalEntry record.
+// TODO: actor Wallet — id, owner, journal: [JournalEntry], derived
+//       balance = sum(journal.delta); invariants: balance >= 0 and
+//       balance == sum(journal.delta).
+// TODO: accepts Credit(amount, key, now), Debit(amount, key, now) on
+//       Wallet — both idempotent on key.
+// TODO: policy TransferAtomicity — flow-scope on Transfer; prose plus
+//       examples covering self-transfer, insufficient funds, replay.
+// TODO: flow Topup(wallet, amount, key, now).
+// TODO: flow Withdraw(wallet, amount, key, now).
+// TODO: flow Transfer(from, to, amount, key, now) — debits source,
+//       credits destination, compensates source on credit failure.
+// TODO: events WalletTopped, WalletWithdrawn, WalletTransferred.
+// TODO: controller Wallets with bearer-auth routes.


### PR DESCRIPTION
Implements the full airbnb example — 8 spec files plus project setup. Closes 8 issues.

## Summary

- Multi-feature project under `examples/airbnb/` exercising the full grammar surface that landed in #19.
- Single-file per feature (flat layout): `auth`, `listings`, `coupons`, `booking`.
- Shared infra: `types.candy`, `events.candy`, `invariants.candy`, `externals.candy`.
- `examples/airbnb/README.md` is the cross-feature symbol contract used to keep all four features internally consistent. Every shared name (types, events, exports, policies) is fixed there.
- `external actor Payments` uses Sketch B (multi-provider via `providers: [Stripe, Polar, Lemon]` + `Actor[Tag]` selector). Per-target SDKs in `preferences.candy`.
- `PlaceBooking` is the canonical multi-actor saga: hold dates → validate coupon → charge → redeem coupon → create Booking, with explicit compensation on every failure path. `PlaceBookingWithFallback` adds a Stripe→Polar→Lemon rescue chain.
- `Booking` actor `subscribe`s to `ChargeSucceeded`/`ChargeFailed` webhooks for async confirmation.
- 1,648 lines of spec across the 8 files; ~280–630 LOC each.

## What this exercises

- `prose` block in every feature (intent, exports, uses, policies)
- `external actor` with multi-provider (`providers:` field, `Actor[Tag]` selector, multi-config blocks, webhook `emits` + `subscribe`)
- Multi-actor saga with explicit `compensate` / `rescue ask … reject`
- Policy attachment at type-, actor-, flow-, controller-, and feature-scope
- Cross-feature `uses:` including the new `feature X for event EventName` form
- Idempotency keys threaded through every replayable flow
- Branded `Money` arithmetic with conservation invariants
- Role-gated controller routes via per-route policies

## Closes

- #2 (types) — \`types.candy\`
- #3 (events) — \`events.candy\`
- #4 (invariants) — \`invariants.candy\`
- #20 (externals) — \`externals.candy\` with multi-provider Payments
- #5 (auth) — \`auth.candy\`
- #7 (listings) — \`listings.candy\`
- #9 (coupons) — \`coupons.candy\`
- #8 (booking) — \`booking.candy\`

## Process notes

- Five sonnet sub-agents wrote the spec files in parallel, coordinating off the README's symbol contract so cross-feature names resolve cleanly. One judgment call (the booking saga's pre-generated booking_id, needed so HoldDates and the rescue ReleaseDates share the same key) was caught in the agent's report and fixed before commit.
- 9 atomic commits (1 setup + 8 specs), each closing or referencing the relevant issue.

## Test plan

- [ ] Manual review of the prose blocks for cross-feature consistency (the contract in README.md is the source of truth)
- [ ] Verify GRAMMAR.md keywords match what the four feature files actually use
- [ ] Conformance evals (#10, #11, #28) come in a separate PR — this one is spec only

🤖 Generated with [Claude Code](https://claude.com/claude-code)