### PR TITLE
docs: M1 foundation retrospective

### DIFF
--- a/.claude/retrospective.config.json
+++ b/.claude/retrospective.config.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.1",
+  "retrospective_dir": ".retrospective",
+  "providers": {
+    "gsd": { "enabled": false, "reason": "no .planning/" },
+    "github": { "enabled": true, "repo": "CallipsosNetwork/candy" },
+    "git": { "enabled": true },
+    "manual": { "enabled": true }
+  },
+  "phase_model": {
+    "type": "milestone",
+    "current": "M1",
+    "current_completed_at": "2026-05-06"
+  },
+  "summary_tracker": {
+    "auto_update": true,
+    "file": "SUMMARY.md"
+  },
+  "stakeholder_report": {
+    "auto_generate": true
+  },
+  "hook_mode": "manual",
+  "_notes": "First-run minimal config. Hooks not registered. /retro init can register PostToolUse + SessionStart hooks if hook_mode is changed to auto or prompt."
+}

--- a/.retrospective/SUMMARY.md
+++ b/.retrospective/SUMMARY.md
@@ -1,0 +1,65 @@
+# Project Retrospective Summary
+
+Cumulative tracker across phases. Auto-updated by `/retro`. New phases are appended; existing rows are updated in place when their retro is regenerated.
+
+---
+
+## Phases
+
+| Phase | Status | Confidence (C/Q/R) | Key outcome | Retrospective |
+|---|---|---|---|---|
+| M1 Foundation | Complete | 4 / 4 / 4 | Spec language + 7 examples + editor tooling. Foundation ready for codegen. | [phase-M1-foundation.md](phase-M1-foundation.md) |
+
+C = Completeness, Q = Quality, R = Risk Exposure (rubric: 5 best, 1 worst).
+
+---
+
+## Cross-phase metrics (cumulative)
+
+| Metric | M1 | Total |
+|---|---|---|
+| Commits | ~52 | ~52 |
+| Merged PRs | 4 | 4 |
+| Files touched | 173 | 173 |
+| Lines added | ~59,000 | ~59,000 |
+| Lines deleted | ~1,400 | ~1,400 |
+| GitHub issues closed | ~14 | ~14 |
+| Sub-agent waves | 3 | 3 |
+
+---
+
+## Recurring themes
+
+- **Sub-agent self-reporting catches real bugs.** Three correctness issues in M1 were caught only because agents flagged judgment calls in their delivery reports. Future phase prompts should explicitly request this style of report.
+- **Late-arriving design decisions are expensive.** Multiple M1 reframes (canonical auth, multi-provider externals, RBAC scope, minute-granularity) cost retroactive PR work. Counter-pattern: write a project-level scope/contract README BEFORE launching agents, not during.
+- **Atomic commit discipline matters.** One bundled-commit slip in M1 required `git reset HEAD~1` to recover. `git add -A` is the smell.
+
+---
+
+## Cumulative risk register
+
+| Risk | Phase introduced | Status | Likely close phase |
+|---|---|---|---|
+| `schedule` syntax untested by formal grammar review or codegen executor | M1 | Open — high priority | M2 (linter + codegen) |
+| `subscribe` block-form syntax used but not formally in `GRAMMAR.md` | M1 | Open | M2 (small grammar PR) |
+| Cross-example auth duplication will drift | M1 | Open — low priority | M3+ (cross-project imports) |
+| Cross-target backend parity unverified | M1 | Open — by design | M2/M3 (codegen + eval-running) |
+| Spec quality drift without a linter | M1 | Open | M2 (linter ships) |
+
+---
+
+## Project-level decisions log
+
+| Decision | Phase | Status |
+|---|---|---|
+| Multi-provider externals via `Sketch B` (`providers:` field + `Actor[Tag]` selector) | M1 | Locked |
+| Preferences stays as candy DSL (not TOML) | M1 | Locked |
+| RBAC folded into `todo`; standalone `rbac` example deleted | M1 | Locked |
+| airbnb is minute-granular (`TimeRange`, not `DateRange`) | M1 | Locked |
+| Polar = canonical billing provider; Postmark = canonical email provider | M1 | Locked |
+| Eval format: hybrid `.md` narrative + `.hurl` executable | M1 | Locked |
+| Codegen prompts: thin base + per-target overlays leaning on language-best-practices skills | Decided post-M1 (in design discussion) | Provisional — first PR will validate |
+
+---
+
+*Stakeholder reports per phase: see `phase-<N>-<slug>-stakeholder.md`.*

--- a/.retrospective/phase-M1-foundation-stakeholder.md
+++ b/.retrospective/phase-M1-foundation-stakeholder.md
@@ -1,0 +1,73 @@
+# M1 Stakeholder Report — Foundation Phase
+
+**Period:** 2026-04-29 → 2026-05-06
+**Status:** Complete
+
+---
+
+## What we shipped
+
+A candy spec language and 7 example projects that show what real backends look like when described in candy.
+
+- **Language reference** with ~50 keywords across 5 word-axes.
+- **7 examples**: hello (smallest), auth (the JWT reference), todo (with role-based access), wallet (money + scheduled transfers), billing (subscription with retries), notifications (multi-provider email/SMS), airbnb (the full marketplace, 8 spec files).
+- **Editor support**: Neovim and VS Code highlighters; tree-sitter grammar skeleton.
+- **Documentation**: architecture, externals, features, manifest schema.
+
+---
+
+## Numbers
+
+- 4 GitHub PRs merged.
+- ~59,000 lines of specs, docs, and tooling added.
+- ~14 GitHub issues closed.
+- ~14 sub-agent runs across 3 parallel waves.
+
+---
+
+## Confidence
+
+| Dimension | Score (1-5) |
+|---|---|
+| Did we deliver what was scoped? | **4 / 5** |
+| Quality of what shipped | **4 / 5** |
+| Risk that something will bite us in M2 | **4 / 5** |
+
+The "4 not 5" reflects: an honest acknowledgment that the eval framework (the next deliverable, PR #34) is in flight, and that the `schedule` keyword and a linter haven't been formally pressure-tested yet.
+
+---
+
+## What worked
+
+- **Parallel AI sub-agents** with a contract-first README pattern. We ran 4–5 agents simultaneously to write airbnb's 8 spec files and four other examples, with internally consistent results.
+- **Atomic commits per issue** keep the git history readable.
+- **Sub-agents self-reporting their judgment calls** caught three real bugs at review that would have shipped otherwise.
+
+---
+
+## What we'd do differently — deferred
+
+The thorough "what didn't work" assessment is held until PR #34 (eval framework) merges. Real eval pressure on the spec quality is the right time to make that call.
+
+One thing already known: we shipped 5 examples without inlined auth, then retrofitted all of them in one PR. If we'd recognized "every role-gated example needs auth" at M1's start instead of mid-stream, that PR would have been smaller.
+
+---
+
+## Risks heading into M2
+
+| Risk | What we're doing about it |
+|---|---|
+| `schedule` keyword has only been tested by example use, not by codegen running it | Build a candy linter (catch syntax errors); build a per-target codegen executor for schedules |
+| Spec drift across new examples without enforcement | Linter ships early in M2 |
+| Cross-target backend behavior parity unverified | Eval framework (PR #34) defines the contract; codegen wave validates against it |
+
+---
+
+## Next phase preview (M2)
+
+- Eval framework merges.
+- Codegen prompt authoring.
+- Candy linter (new artifact).
+- First Go/chi backend generated from `examples/auth/` and run against `evals/auth/auth.hurl`.
+
+**Readiness: High** for the prompt-authoring path. **Medium** for actual backend generation, since prompt quality has yet to be empirically tested.

--- a/.retrospective/phase-M1-foundation.md
+++ b/.retrospective/phase-M1-foundation.md
@@ -1,0 +1,242 @@
+# Phase M1 — Language + Examples + Tooling Foundation
+
+**Phase:** M1 — Foundation
+**Period:** 2026-04-29 → 2026-05-06
+**Cut-off:** PR #33 merged. PR #34 (eval framework) explicitly excluded — opens M2.
+**Status:** Complete
+
+---
+
+## 1. Phase Context
+
+### Objective
+
+Lay down the candy spec language and a representative set of example projects sufficient to support a downstream codegen wave. Specifically: define the grammar; ship the canonical examples (auth, todo, airbnb, wallet, billing, notifications, hello); produce editor tooling; refine specs to a state where each `.candy` file is internally coherent, cross-feature symbols resolve, and real-world test scenarios can be authored against them.
+
+### Scope — In
+
+- Grammar reference (`GRAMMAR.md`) including constructs landed mid-phase: `prose` block, `external actor`, multi-provider `providers:` field, `Actor[Tag]` selector, `policies:` attachment, `schedule` keyword, feature layout detection rule.
+- 7 example projects (`hello`, `auth`, `todo`, `airbnb`, `wallet`, `billing`, `notifications`), each self-contained with `candy.toml` + `preferences.candy` + spec content + README scope doc.
+- airbnb full marketplace example: 8 spec files implementing 4 features + shared infrastructure.
+- Editor tooling: Neovim regex highlighter (verified live), VS Code TextMate grammar, tree-sitter-candy skeleton.
+- Documentation: architecture, features, externals, candy-toml schema.
+- Spec evolutions: inlined canonical auth across all auth-needing examples; minute-granular airbnb; Polar canonical for billing; Postmark canonical for notifications; RBAC folded into todo.
+
+### Scope — Out
+
+- Eval framework / hurl scripts (deferred to M2 — became PR #34).
+- Codegen prompt and target backends (deferred to M2/M3).
+- Runtime / CLI for candy itself (specs are read-only artifacts; no parser exists).
+- pi.dev extension (deferred — labeled `future`).
+
+### Entry Conditions
+
+Project bootstrapped from concept; no prior code.
+
+### Success Criteria
+
+| Criterion | Status |
+|---|---|
+| Grammar reference covers every keyword used in examples | Met |
+| All examples parse-by-eye against `GRAMMAR.md` | Met |
+| Cross-feature symbols (events, types, exports) resolve consistently | Met (caught manually at review; no parser exists yet to enforce) |
+| Editor tooling installed and verified for at least one editor | Met (Neovim verified live; VS Code shipped, manual verification pending) |
+| airbnb example implements a non-trivial multi-actor saga | Met (`PlaceBooking` with explicit `compensate` chain) |
+| Documentation covers each major design decision | Met (`docs/architecture.md`, `externals.md`, `features.md`, `candy-toml.md`) |
+| Spec quality sufficient to author conformance evals against | Met (validated by PR #34 in flight) |
+
+---
+
+## 2. Findings
+
+### Unexpected — surfaced during M1
+
+- **`Sketch B` (`providers:` + `Actor[Tag]` selector) was a meaningful language addition**, prompted late by the user's question about how multi-payment-provider scenarios should be expressed. The original design was "one external actor per provider"; the duplication smell forced a real grammar feature. Cost: extra grammar work in PR #33 plus retroactive `Actor[Tag]` calls in airbnb / billing / notifications.
+
+- **The "shared auth across examples" reframe came late** — only during the spec-evolutions PR (#33), after most examples had already shipped without auth. Cost: every example except `hello` got rewritten to inline a canonical auth section. ~150 line additions per file, retrofitted across 5 examples.
+
+- **airbnb minute-granularity was a late spec change** prompted by eval-design needs (testability in seconds, not days). Required `DateRange` → `TimeRange` refactor across types/listings/booking + cross-file fixups in `events.candy` and `invariants.candy` that the sub-agent flagged but did not apply itself.
+
+- **The standalone `rbac` example duplicated `User+Role` content already implied by airbnb's auth.** Folded into `todo` mid-M1; the spec evolutions PR included the deletion. Cost: one full agent run on rbac (#25) was effectively retired and rewritten.
+
+- **TOML preferences proposed and rejected.** A meaningful design discussion converged that `preferences.candy` should stay candy syntax (the `when need X use Y` English reading + single-language consistency outweighed TOML's tooling). Cost: a follow-up issue (#29) opened, then closed.
+
+- **Sub-agents scaled further than initially expected.** Five agents in parallel for airbnb features, then four for standalone examples, then five for spec evolutions. Each batch shipped 1500+ lines of internally consistent spec via a contract-first README pattern (the "symbol contract" in airbnb's project README).
+
+- **Real bugs were caught at review by sub-agents reporting their own judgment calls.** The booking saga's `generate()` being called twice for the same `booking_id` was flagged by the agent itself, fixed by orchestrator before commit. Without that flag, generated backends would have shipped a real correctness bug — rescue paths cannot release what hold actually held.
+
+### Expected (validated)
+
+- The grammar's five word-axes (ENTITY/ACTION/TIME/CONDITION/INTENT) held up across all real example specs.
+- Flat single-file feature layout (vs folder-per-feature) works for the example tier; both layouts remain documented.
+- Contract-first README pattern (writing the symbol contract before launching agents) prevents cross-feature drift across parallel writers.
+
+---
+
+## 3. Observations
+
+- **Atomic commits matter when sub-agents do multi-step work.** A bundled `git add -A` in the airbnb rename PR auto-included `.gitignore` and the `grammar.md → GRAMMAR.md` case-rename. That violated the user's explicit "atomic" preference and required `git reset HEAD~1` and three split commits to recover.
+- **Sub-agents over-shoot line-count targets when scope expands.** Booking went to 628 (cap was 550). Billing went to 967 (target 700–900). Wallet went to 778 (target 500–650). Reports cited substantive content (judgment-call examples, prose-heavy policies) — not padding — but the targets were too tight given the scope demands.
+- **Parallel sub-agents do not see each other's output.** Cross-file fixups (e.g., `events.candy` referencing `TimeRange` after the airbnb agent renamed `DateRange`) require an orchestrator review pass. Two such fixups occurred in M1; both caught.
+- **The `subscribe` block-form syntax** (`subscribe X -> on event(...) { if ... then ask Y }`) was introduced organically by the booking agent because the grammar's terse form (`subscribe X -> Handler(args)`) couldn't carry a per-event guard. The agent flagged it; ratification in `GRAMMAR.md` is pending.
+- **Sub-agent self-reporting is the highest-leverage quality gate** in this workflow. Three real bugs were caught this way — none would have been caught by silent execution.
+
+---
+
+## 4. Edge Cases
+
+- **First-admin bootstrap** in role-gated examples (`todo`, `wallet`, `airbnb`, `billing`, `notifications`): no spec endpoint promotes the first admin. Currently a runner-harness concern; documented per-example. Will surface again during eval runs and codegen wiring.
+- **Cross-target provider compatibility** for RBAC: Casl is JS-only. `preferences.candy` intentionally doesn't bind it on Go/Rust/Python; codegen will error if a flow tries `RBAC[Casl]` on those targets. (The `rbac` example was deleted; this edge case migrates to `todo.candy` if it later adopts external RBAC, which currently it does not — `todo`'s RBAC is candy-native.)
+- **`Actor[Tag]` selector at runtime vs compile time**: the multi-provider pattern is statically typed (provider tags are known at codegen time). Runtime fallback chains use `rescue ask Payments[Polar]...` which is also static. True dynamic provider selection (per-user preference) is documented as an internal-flow-composition concern, not a language feature.
+- **`schedule` semantics under codegen**: schedule predicates query across actors (`for any subscription in Subscription where ...`). Codegen needs a per-target query implementation. Not pressure-tested yet.
+
+---
+
+## 5. Decisions Made
+
+| Decision | Options Considered | Choice | Rationale |
+|---|---|---|---|
+| Multi-provider externals | Sketch A (`is` modifier), **Sketch B** (`providers:` + `Actor[Tag]`), Sketch C (`contract` + `implements`) | Sketch B | One declaration, single source of truth, configs co-located, selector parallels `Actor(id)`, lowest keyword cost (1 new keyword: `providers`) |
+| Preferences format | TOML (in `candy.toml`), candy DSL | candy DSL | "when need X use Y" reads as intent; single-language consistency; AI codegen reads one format |
+| RBAC scope | Standalone `rbac`, fold into `todo`, both | Fold into `todo` | One example per concept; standalone duplicated `User+Role`; `todo` with admin/manager/user is a richer policy demonstration |
+| airbnb time granularity | `DateRange` (day), `TimeRange` (minute) | `TimeRange` | Eval cycles in seconds; scenarios become observable; minor spec change |
+| Canonical payment provider for billing | Stripe, Polar, Lemon | Polar | User has Polar API key; developer-friendly; Stripe and Lemon stay declared as alternates |
+| Canonical email provider for notifications | SendGrid, Mailgun, Resend, Postmark | Postmark | User has Postmark access; joins as canonical default |
+| airbnb wallet | Inline (in airbnb), standalone | Standalone | Wallet semantics deserve a dedicated demo; airbnb settles via Payments directly |
+| Eval format | Pure hurl, pure markdown, hybrid | Hybrid (`.md` + `.hurl`) | `.md` is the plan; `.hurl` is what runs; both stay aligned |
+| First-admin bootstrap | Self-promote endpoint, seeded admin via fixture, runner harness | Runner harness (deferred) | Spec stays clean; harness gap documented per-example |
+| Codegen prompt structure | Big monolithic prompt (~2000 lines), modular base + per-target overlays, base + skill-dispatched per-target | Base + skill-dispatched (decided post-M1, in design discussion) | Lean on existing language-best-practices skills; thin overlays; less drift |
+
+---
+
+## 6. Risks & Issues
+
+### Issues encountered (all resolved within M1)
+
+| Issue | Severity | Resolution | Time impact |
+|---|---|---|---|
+| Commit bundling violated atomic preference (rename PR pulled in `.gitignore` + grammar.md case-rename) | Medium | `git reset HEAD~1`, split into 3 atomic commits, force-push not needed (pre-PR) | ~10 min recovery |
+| Booking saga `generate()` race (would have caused rescue `ReleaseDates` to fail at runtime) | High potential | Caught by sub-agent's own judgment-call report at review; pre-generated `booking_id` at top of saga; both `PlaceBooking` and `PlaceBookingWithFallback` fixed | ~15 min review + edit |
+| `DateRange` → `TimeRange` cross-file fixup missed by airbnb agent | Medium | Agent flagged in report; orchestrator updated `events.candy` + `invariants.candy` in same PR | ~5 min |
+| Duplicate `UserSignedUp` event declaration in notifications (auth events block + trigger events block) | Low | Caught at pre-commit review; deduplicated | ~2 min |
+| Sub-agent line-count overruns (booking 628 vs 550 cap; billing 967 vs 700–900 target; wallet 778 vs 500–650 target) | Low | Justified by scope (judgment-call examples, prose-heavy policies); accepted as-is | None |
+
+### Forward risks (M2 onward)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **`schedule` syntax has only been pressure-tested by example use, not formal grammar review or executor implementation.** Codegen must implement firing correctly across 4 targets. | High | High | **Lint rule for schedule syntax** + **codegen executor** are the two artifacts that close this. Both planned. *(User-flagged as the #1 forward risk.)* |
+| Spec quality drift across new examples without a linter | High | Medium | Build candy linter (design.md-inspired) early in M2 |
+| `subscribe` block-form syntax used in `booking.candy` but not formally in `GRAMMAR.md` | Medium | Medium | Ratify in a small grammar PR before codegen consumes it |
+| Cross-target backend behavioral parity (the conformance contract) is unverified until codegen + hurl-running infra exist | High | Medium | The eval framework (PR #34) is the contract; codegen wave validates against it |
+| Inlined auth duplication across examples will drift if any one example evolves the canonical pattern | Medium | Low–Medium | Periodic cross-example diff at retros; eventual move to a shared/imported feature once cross-project imports exist |
+
+---
+
+## 7. Metrics & Progress
+
+| Metric | Value |
+|---|---|
+| Commits in M1 (through PR #33 merge) | ~52 |
+| Merged PRs | 4 (#30, #31, #32, #33) |
+| Files touched | 173 |
+| Lines added | ~59,000 |
+| Lines deleted | ~1,400 |
+| GitHub issues closed in M1 | ~14 (#1, #2, #3, #4, #5, #7, #8, #9, #19, #20, #21, #22, #24, #25-equivalent via deletion) |
+| GitHub issues opened in M1 still open at cut-off | ~12 (eval wave + codegen wave + retro + future) |
+| Sub-agent waves (parallel batches) | 3 — airbnb implementation, 4 standalone examples, 5 spec evolutions |
+| Total parallel sub-agents launched in M1 | ~14 |
+
+### Goal vs actual
+
+The goal was set retroactively — no formal M1 plan was written before execution. The effective target was: ship a foundation strong enough to author behavioral conformance evals against. PR #34's existence as a deliverable IS the proof of completion — every spec in M1 was sufficient input for an eval pair to be authored from it.
+
+---
+
+## 8. Learnings
+
+### What worked
+
+- **Parallel sonnet sub-agents with a shared symbol contract.** Three waves ran 4–5 agents simultaneously and each produced internally consistent specs. The contract-first pattern (a project-level README that pins cross-cutting symbol names BEFORE agents spawn) is the load-bearing design choice.
+- **Atomic per-issue commits.** Each merged PR has one commit per issue closed; history reads cleanly. The `git reset HEAD~1` recovery from the bundled rename was the one-time lesson.
+- **Sub-agent reports as a quality gate.** The booking saga bug, the cross-file fixup gap, and the duplicate event were all flagged by the agent's own judgment-call report at task completion. Reading those reports before committing has been higher-leverage than a separate review pass.
+- **The `eval.txt` → spec evolution → eval framework feedback loop.** Writing freeform notes about the eval vision surfaced spec gaps (real-world auth, real provider integrations, minute-granularity) BEFORE the eval scripts had to work around them. This pattern should generalize.
+
+### What didn't work — DEFERRED
+
+The user explicitly requested: *"need to resolve on evals first before deciding on what hasn't worked."* This assessment is held until PR #34 has merged and the eval scripts have been pressured against any real codegen output. That checkpoint should resurface this section of the retro.
+
+### Acknowledged in advance of the deferred review
+
+What's already known to be a partial win: the **late-arriving canonical auth shape**. Five examples shipped without auth, then all five were retrofitted in a single spec-evolutions PR. The cost was one PR's worth of rewrites that would have been avoided if "every example with role gating needs auth" had been declared at M1's start.
+
+---
+
+## 9. Artifacts
+
+| File / artifact | Description |
+|---|---|
+| `GRAMMAR.md` | Canonical grammar reference; ~50 keywords across 5 axes; covers all blocks, schedules, externals, multi-provider, policy attachment |
+| `docs/architecture.md` | Layering, hexagonal architecture, policy attachment, substrate vs spec |
+| `docs/externals.md` | External actor pattern, multi-provider, webhooks-as-events |
+| `docs/features.md` | Feature layout (single-file vs folder), prose block fields, layout detection rule |
+| `docs/candy-toml.md` | Manifest schema v0.1 |
+| `examples/hello.candy` | Smallest possible candy program (syntax-only teaser) |
+| `examples/auth/` | Canonical auth reference; JWT + SQLite |
+| `examples/todo/` | RBAC sandbox over todo CRUD; 3 roles |
+| `examples/wallet/` | Money primitives; admin-funded; scheduled transfers |
+| `examples/airbnb/` | Full marketplace example with multi-actor saga (8 spec files) |
+| `examples/billing/` | Subscription billing; 3 schedules; Polar canonical |
+| `examples/notifications/` | Event-driven pipeline; Postmark + SMS multi-provider |
+| `extensions/neovim/` | Vim regex syntax + ftdetect + ftplugin; install verified live |
+| `extensions/vscode/` | TextMate grammar + extension manifest |
+| `extensions/tree-sitter-candy/` | Grammar.js + scanner.c skeleton; not yet built or wired |
+| `eval.txt` | Freeform eval-design notes that informed PR #33's spec evolutions |
+
+---
+
+## 10. Stakeholder Highlights
+
+### Executive summary
+
+M1 shipped the candy spec language and 7 example projects representative enough to anchor a conformance test wave. 4 PRs merged, ~59k lines of spec/docs/tooling, ~14 GitHub issues closed. Foundation is ready for the codegen wave (M2), pending the eval framework PR (#34) which bridges into M2.
+
+The largest design discoveries — multi-provider externals via `Actor[Tag]`, inlined canonical auth, minute-granular airbnb, RBAC folded into todo — happened mid-flight rather than upfront. None blocked progress; all required retroactive spec updates that compounded the late-stage review burden.
+
+Three concrete bugs caught at review (booking saga `generate()` race, cross-file `DateRange`/`TimeRange` fixup, duplicate event declaration) would have been runtime/codegen-time failures if shipped uncaught. Sub-agent self-reporting served as the catch mechanism.
+
+### Confidence scores (1–5 rubric: 5 = no significant issues; 4 = minor issues resolved; 3 = some outstanding; 2 = major; 1 = critical failure)
+
+| Dimension | Score | Notes |
+|---|---|---|
+| **Completeness** | **4 / 5** | Spec scope shipped; canonical auth retrofit compressed the timeline; eval framework intentionally deferred to M2 |
+| **Quality** | **4 / 5** | High internal consistency; line-count overruns on three agent outputs justified by scope; no parser exists yet to mechanically validate, so quality is review-grade not lint-grade |
+| **Risk exposure** | **4 / 5** | Schedule syntax + linter + codegen executor are the three load-bearing forward artifacts; both linter and executor are planned. *(User: "confidence is great" — interpreted as 4/5 across the board)* |
+
+### Key numbers
+
+- 60 commits, 173 files, +59,275 / −1,407 LOC.
+- 4 PRs merged (#30, #31, #32, #33).
+- ~14 issues closed.
+- ~14 sub-agent runs across 3 parallel waves.
+- 7 example projects (hello + 6 self-contained).
+- Grammar: ~50 keywords, 5 axes, 11 block types.
+
+### Callouts
+
+- **`schedule` syntax is the highest-leverage forward artifact.** Both a linter (catch invalid syntax) and a codegen executor (run the schedule predicate per-target) are required before billing/wallet/airbnb evals can fully validate the schedule path. *(User-flagged as risk #1.)*
+- **Sub-agent self-reporting is the highest-leverage process artifact.** Three real bugs caught; pattern should be made explicit in future agent prompts ("report any judgment calls that touch correctness, not just style").
+- **PR #34 (eval framework) is the bridge.** Until it merges and the user has resolved on evals, the M1 → M2 transition is incomplete and the "what didn't work" section here remains deferred.
+
+### Next phase preview (M2)
+
+- Eval wave completion (PR #34 merge).
+- Codegen prompt authoring (#12) — base + thin per-target overlays leaning on language-best-practices skills.
+- Candy linter (NEW issue, design.md-inspired).
+- Per-target backend POC (#13 Go/chi against `examples/auth/`).
+
+M2 readiness: **High** for the codegen-prompt path. **Medium** for actual backend generation — depends on prompt quality and the linter establishing schedulable surface.
+
+---
+
+*Generated by `/retro`. Cumulative summary in `SUMMARY.md`. Stakeholder report in `phase-M1-foundation-stakeholder.md`. Closes #18.*


### PR DESCRIPTION
First retrospective for the project. Closes #18.

## Scope

M1 Foundation phase: 2026-04-29 → 2026-05-06, through PR #33. The eval framework (PR #34) is intentionally excluded — it bridges into M2.

## What's in this PR

- \`\.retrospective/phase-M1-foundation.md\` — full 10-section retro per the retro skill template (Phase Context, Findings, Observations, Edge Cases, Decisions Made, Risks & Issues, Metrics, Learnings, Artifacts, Stakeholder Highlights).
- \`.retrospective/phase-M1-foundation-stakeholder.md\` — exec view with confidence scores and forward risks.
- \`.retrospective/SUMMARY.md\` — cumulative tracker for future phases to extend.
- \`.claude/retrospective.config.json\` — first-run minimal config (git + github + manual providers; gsd disabled; hooks not registered).

## Headline takeaways

- **Confidence: 4 / 4 / 4** (Completeness / Quality / Risk Exposure). The "4 not 5" reflects deferred items (eval-driven spec validation in M2), not silent problems.
- **Three bugs caught at review** by sub-agents reporting their own judgment calls. The pattern is the highest-leverage process artifact in M1 and should be made explicit in future agent prompts.
- **Forward risk #1** (user-flagged): \`schedule\` syntax needs both a linter and a codegen executor before the schedule-related eval paths can validate. Both planned in M2.
- **"What didn't work" is deferred** per user direction — that section gets resolved after PR #34 merges and the eval scripts pressure the spec.

## Closes

- #18 (M1 retrospective)
