### PR TITLE
feat(prompts): codegen base + 4 target overlays

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -191,6 +191,50 @@ actor Booking(id: Id) {
 The subscriber doesn't know which provider fired the event; the contract is
 the event shape on the external actor.
 
+### subscribe — terse and block forms
+
+`subscribe` has two surface forms. Both are valid; pick whichever reads
+clearer for the handler.
+
+**Terse form** — direct dispatch to a flow or actor message. The
+arguments are positional fields from the event payload, in declaration
+order:
+
+```candy
+subscribe ChargeSucceeded -> ConfirmBooking(charge)
+```
+
+**Block form** — destructures the event payload by field name into a
+named binding, then runs a body. The body is one or more
+flow-shape statements: `ask`/`tell`/conditionals built from `if … then`.
+Use this when the subscriber needs a guard or wants to bind multiple
+payload fields by name:
+
+```candy
+subscribe ChargeSucceeded -> on event(charge, booking, at) {
+  if booking == self.id then ask Confirm(charge, at)
+}
+
+subscribe ChargeFailed -> on event(charge, booking, reason, at) {
+  if booking == self.id then ask SetCancelled(reason, none, at)
+}
+```
+
+Rules:
+
+- The names inside `on event(...)` must match field names declared in
+  the event's `payload:`. Unknown names are an error.
+- Names may be a subset of the payload — bind only what the body uses.
+- Body statements are subject to the same flow semantics: `ask`
+  awaits, `tell` is fire-and-forget, conditionals use `if cond then
+  expression` (no `else` returns unit on the false branch).
+- Each `subscribe` line registers one subscriber on the enclosing
+  actor; multiple subscribes on the same event compose at codegen
+  time into separate handler registrations.
+- Block form is required when the subscriber is guarded by event
+  payload (the common "match on `self.id`" pattern at codegen-derived
+  webhook dispatch). Terse form should not carry a guard.
+
 Webhook routes are **codegen-derived** — when an external actor declares
 `emits`, the codegen produces the inbound HTTP handler that validates the
 provider's signature and dispatches to subscribers. The spec does not

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,68 @@
+# prompts/
+
+Codegen system prompts. The contract by which a candy spec becomes an
+idiomatic backend in Go, Rust, TypeScript, or Python.
+
+## Structure
+
+```
+prompts/
+  README.md                  — this file.
+  codegen-base.md            — universal codegen contract.
+  codegen-go.md              — Go/chi overlay.
+  codegen-rust.md            — Rust/axum overlay.
+  codegen-typescript.md      — TypeScript/hono overlay.
+  codegen-python.md          — Python/fastapi overlay.
+```
+
+The base prompt is universal: block-by-block translation contract,
+cross-cutting rules, what to refuse. The four overlays are thin —
+target framework wiring, library bindings, idiomatic shape per block.
+
+Two of the overlays (Go, Rust) explicitly dispatch to existing Claude
+Code skills (`golang-best-practices`, `rust-best-practices`) for
+idiom guidance. The other two (TypeScript, Python) carry more inline
+idiom because no equivalent skill ships in this repo's environment.
+
+## Loading order at codegen time
+
+1. `GRAMMAR.md` (root of repo).
+2. `prompts/codegen-base.md`.
+3. `prompts/codegen-<target>.md`.
+4. The skill the overlay names, if any.
+5. The project's `candy.toml`, `preferences.candy`, and every `.candy`
+   file under it.
+
+## How they're invoked
+
+The candy CLI's `gen` subcommand (Phase C onward; see issues
+#13/#14/#15/#16) loads these prompts plus the project spec and asks an
+LLM to produce the target tree. v0.1 is prompt-driven; the prompts
+themselves can also be loaded by hand into a Claude Code session for
+generation.
+
+## Versioning
+
+`candy.toml`'s `[deps]` table currently informational; the entry
+`"candy/codegen-go" = "0.1"` (and equivalent) names this prompt bundle
+at version 0.1. Bumping the version is a contract change — every
+example must regenerate cleanly under the new prompt.
+
+## Conformance
+
+Every overlay's "Verification before reporting done" section is the
+acceptance gate. A target is generated correctly when:
+
+- The chosen target's lint/typecheck/test commands all pass.
+- The corresponding `evals/<feature>/<feature>.hurl` runs green
+  against the generated server.
+
+Don't edit hurl files to make them green; the spec mapping is the bug.
+
+## Refs
+
+- Phase A of `.claude/session-handoff.txt` (closed by this PR; closes #12).
+- Decision context: GitHub issue #36 (closed) — codegen architecture
+  decisions: option (c) base-plus-thin-overlays-with-skill-dispatch.
+- `evals/README.md` — the conformance contract.
+- `GRAMMAR.md` — the language reference.

--- a/prompts/codegen-base.md
+++ b/prompts/codegen-base.md
@@ -201,7 +201,26 @@ A typed message broadcast to subscribers.
 | `order: by Field`     | Deliver in order of `Field` per consumer.                  |
 | `order: total`        | Single global order.                                       |
 | `order: causal`       | Vector-clock ordering.                                     |
-| `subscribe X -> Op`   | Register the subscriber inside the actor's bootstrap.      |
+| `subscribe X -> Op`   | Register the subscriber on the enclosing actor. Two forms — see below. |
+
+`subscribe` has two surface forms (GRAMMAR.md "subscribe — terse and block forms"):
+
+- **Terse**: `subscribe X -> Handler(args)`. Arguments are positional
+  fields from the event payload. Compile to a direct dispatch.
+- **Block**: `subscribe X -> on event(field, ...) { body }`. The
+  `on event(...)` list destructures the payload by field name; the
+  body is one or more flow-shape statements (`ask`/`tell`/`if … then
+  ...`). Compile to: receive event → bind the named fields → run the
+  body in the subscribing actor's context (`self` is the instance
+  that owns the subscribe).
+
+Block-form bindings inside `on event(...)` must match field names
+declared in `event X { payload: { ... } }`. Unknown names are a
+generation error. Names may be a subset of the payload — bind only
+what the body uses. Use the block form when the subscriber needs a
+guard (the common `if event.field == self.id then ask ...` pattern at
+codegen-derived webhook dispatch); the terse form should not carry a
+guard.
 
 If the runtime substrate (the target's chosen queue/event-bus library)
 does not support a declared delivery mode, refuse to generate and report

--- a/prompts/codegen-base.md
+++ b/prompts/codegen-base.md
@@ -1,0 +1,507 @@
+# candy codegen — base prompt
+
+You are generating an idiomatic backend from a candy spec. This document is
+the universal contract. A target overlay (`codegen-{go,rust,typescript,python}.md`)
+layers language-specific idioms on top.
+
+Loading order:
+
+1. Read `GRAMMAR.md` (authoritative grammar reference).
+2. Read this document.
+3. Read the target overlay for the language you are generating.
+4. Where the overlay says "dispatch to `<language>-best-practices`", load
+   that skill before emitting code.
+5. Read the project's `candy.toml`, `preferences.candy`, and every `.candy`
+   file under the project root.
+
+You generate code into `targets/<lang>/` at the project root. Generated
+code is the source of truth for the runtime; the spec is the source of
+truth for behaviour. Both are checked in.
+
+---
+
+## 1. What you are reading
+
+Every input file is one of:
+
+| File                       | Purpose                                                      |
+|----------------------------|--------------------------------------------------------------|
+| `candy.toml`               | Project name, runtime version, targets, deps.                |
+| `preferences.candy`        | Per-target library and idiom preferences (`when need X use Y`). |
+| `*.candy` (single-file)    | A feature when no folder of that name exists.                |
+| `<feature>/prose.candy`    | The entry point of a folder feature.                         |
+| `<feature>/*.candy`        | Sibling spec files (`actors.candy`, `flows.candy`, ...).     |
+| `evals/<feature>/*.hurl`   | Behavioural conformance tests. The contract you must pass.   |
+
+You **do not** receive `.md` design documents at codegen time. The spec
+(`.candy`) and the conformance tests (`.hurl`) are the inputs. Every
+behaviour the hurl exercises must be reachable in the code you emit.
+
+### Feature layout detection
+
+For each feature directory under `spec/` (or each top-level `.candy` file
+when the project is flat):
+
+| State                                  | Layout                |
+|----------------------------------------|-----------------------|
+| `<name>/prose.candy` exists            | Folder feature        |
+| `<name>.candy` exists at the same level | Single-file feature   |
+| Both exist                             | **Error** — refuse to generate; report ambiguity. |
+| Neither                                | Not a feature.        |
+
+The `prose` block is the feature's public interface. Read it before any
+other block in that feature.
+
+### Reading `preferences.candy`
+
+`preferences.candy` is candy DSL, not TOML. Each `target <name> {}` block
+holds either `notes:` prose or `when need <concept> use <library>`
+sentences. The concept and library identifiers are user-chosen; resolve
+them against your knowledge of the ecosystem and the conventions in the
+target overlay. Examples:
+
+```candy
+target go         { when need database use sqlite, when need jwt use golang-jwt }
+target rust       { when need database use rusqlite, when need jwt use jsonwebtoken }
+target typescript { when need database use better-sqlite3, when need jwt use jsonwebtoken }
+target python     { when need database use sqlite3, when need jwt use pyjwt }
+```
+
+If a concept is referenced in the spec (e.g. the spec calls
+`Payments.Charge`) but no `when need payments use ...` line exists, fall
+back to the overlay's documented default for that concept.
+
+---
+
+## 2. The 11 block types — universal mapping contract
+
+Each block has a fixed translation contract. Target overlays specify the
+idiomatic shape; this section specifies the **invariants** that hold
+across all targets.
+
+### `actor`
+
+A stateful entity with private state and message handlers.
+
+| Spec construct                | Emission contract                                   |
+|-------------------------------|-----------------------------------------------------|
+| `state { f: T = default }`    | A persistent record with a column/field per `f`.    |
+| `derive x = expr`             | A computed accessor on the record. Never persisted. |
+| `invariant <pred>`            | A runtime check enforced before each `commit`.      |
+| `audit name { ... }`          | An append-only history table; one row per matched event. |
+| `accepts Op(args) -> Result<Ok, Err>` | A handler function returning that exact result. |
+| Implicit `Type.create(...)`   | Generate a constructor function.                    |
+| Implicit `Type.findBy(field: v)` | Generate a lookup-by-field finder.                |
+| Implicit `Type(id)`           | Generate an addressable instance handle by id.      |
+| `self`                        | Bound to the current actor instance inside `accepts`. |
+
+Every actor's state is private. Cross-actor reads or writes go through a
+`flow`. Generated code must enforce this — even if the persistence layer
+would technically allow direct reads.
+
+### `external actor`
+
+Same shape as `actor`, modifier flips ownership. No `state {}` block.
+
+| Spec construct       | Emission contract                                          |
+|----------------------|------------------------------------------------------------|
+| `config: ...`        | A struct holding configuration. `secret "ENV"` reads from env. |
+| `accepts Op(...)`    | An outbound SDK call. Wrap the SDK; map its errors to declared variants. |
+| `emits Event { ... }` | A subscriber-dispatching handler. Webhook routes are codegen-derived (see §6). |
+| `providers: [A, B, C]` | Multi-provider mode. Generate one binding per tag.       |
+| `Actor[Tag].Op(...)` | Dispatches to the binding for `Tag`. Each tag has its own config block. |
+
+Provider binding selection: `preferences.candy` line `when need <tag-lower> use <library>` picks the SDK for `<tag>`. If a provider tag has no preference line, generate a stub binding that returns a `NotConfigured` error variant at runtime and emit a TODO comment naming the provider.
+
+### `flow`
+
+A multi-actor saga.
+
+| Spec construct                        | Emission contract                                   |
+|---------------------------------------|-----------------------------------------------------|
+| `flow Name(args) -> Result<Ok, Err>`  | A function with that exact result type.             |
+| `step name = ask Actor.Op(...)`       | A sequential await. Bind the success value to `name`. |
+| `step name = tell Actor.Op(...)`      | Fire-and-forget. Do not await. Returns unit.        |
+| `rescue compensate prior; reject Err` | On failure, execute the compensation chain (named steps in reverse), then reject. |
+| `rescue ask Actor[Other].Op(...)`     | Provider fallback. Try alternative; final `rescue reject` terminates. |
+| `commit value`                        | Successful return.                                  |
+| `emit Event { ... }`                  | Publish to subscribers. Honour delivery semantics (§event). |
+
+Compensation: when a `step` named `paid` rejects after `step held = ...`
+already committed, generate a call that asks `held`'s declared
+compensating message. Actors are responsible for declaring their
+compensators; if a flow's compensation chain references a step whose
+actor declares no `Cancel`/`Release`/equivalent, this is a generation-time
+error — refuse and report.
+
+### `schedule`
+
+A recurring or one-shot flow.
+
+```candy
+schedule ChargeCycle(now)
+  every 30d
+  for any subscription in Subscription where status == Active
+```
+
+Emission contract:
+
+- A scheduler component for the target (see overlay) that fires at the
+  declared cadence.
+- For each fire, evaluate the `for any X in Y where <pred>` clause as a
+  query against `Y`'s actor table.
+- Invoke the named flow with the matched instance + `now`.
+- Emit a `ScheduleFired` event for observability.
+- No implicit retries. If the flow rejects, that is final for this
+  firing; the next cadence still fires normally.
+
+### `controller`
+
+HTTP surface. Thin: routing, auth wiring, body shape, response mapping.
+
+| Spec construct                      | Emission contract                                   |
+|-------------------------------------|-----------------------------------------------------|
+| `METHOD /path -> Target`            | A route handler in the target framework.            |
+| `auth: none \| bearer \| basic`     | Middleware wiring per target overlay.               |
+| `body: { f: T, ... }`               | Request body schema; reject malformed input with 400. |
+| `map: ok(v) -> Status Shape`        | On success, return that status with that body shape. |
+| `map: err(Variant) -> Status { ... }` | On declared error variant, return that status with that body shape. |
+| `auth: bearer` implicits            | `self` = authenticated principal id; `bearer` = raw token. |
+| `now` (implicit)                    | Inject the current timestamp at the route boundary, not inside the handler. |
+
+Controllers carry no business logic. Every code path inside a generated
+handler is one of: parse → validate → dispatch (flow or actor message) →
+map response. If you find yourself writing an `if`/conditional inside a
+controller for non-validation reasons, the logic belongs in a flow.
+
+### `policy`
+
+A named rule cluster with examples.
+
+| Spec construct                          | Emission contract                                 |
+|-----------------------------------------|---------------------------------------------------|
+| `policy Name { intent, examples }`      | A function the spec invokes via `step ok = MyPolicy(input) rescue reject Err`. |
+| `examples:` cases                       | Generate unit tests asserting each `given`/`then` mapping. |
+| Attachment scopes (`type`, `actor`, `flow`, `controller`, `prose`) | Wrap the appropriate emission point. See §3 below. |
+
+When a policy's intent is prose-only (no algorithmic body), implement it
+literally from the prose. The examples are the conformance: generated
+unit tests must pass for every listed `given`/`then`.
+
+### `event`
+
+A typed message broadcast to subscribers.
+
+| Spec construct        | Emission contract                                          |
+|-----------------------|------------------------------------------------------------|
+| `payload: { ... }`    | A typed message struct/record.                             |
+| `delivery: eager`     | At-least-once. May duplicate. Subscribers must be idempotent. |
+| `delivery: strict`    | Exactly-once. Use the target's transactional outbox or equivalent. |
+| `delivery: weak`      | At-most-once. Best effort; drop on failure.                |
+| `order: by Field`     | Deliver in order of `Field` per consumer.                  |
+| `order: total`        | Single global order.                                       |
+| `order: causal`       | Vector-clock ordering.                                     |
+| `subscribe X -> Op`   | Register the subscriber inside the actor's bootstrap.      |
+
+If the runtime substrate (the target's chosen queue/event-bus library)
+does not support a declared delivery mode, refuse to generate and report
+the mismatch. Don't downgrade silently.
+
+### `type` and `enum`
+
+| Spec form                                          | Emission contract                                 |
+|----------------------------------------------------|---------------------------------------------------|
+| `type Name int { unit: minor, currency: USD }`     | A branded integer; arithmetic preserves the brand. |
+| `type Money int { ... }`                           | **Never represent as float.** Integer minor units throughout. |
+| `type Name string { max: 320, format: rfc5322 }`   | A branded string; constructor validates `max` and `format`. |
+| `type Name opaque { max: 128 }`                    | A branded byte-or-string blob; no parsing.        |
+| `type Name decimal { ... }`                        | Use the target's exact-decimal library; never `f64`. |
+| `type Name instant { tz: utc }`                    | A UTC timestamp.                                  |
+| `type Name { f: T }`                               | A record. Plain struct.                           |
+| `enum Status { Pending, Confirmed }`               | Sum type.                                         |
+| `[T]`                                              | List of `T`.                                      |
+| `Option<T>` or `T?`                                | Optional.                                         |
+| `Result<Ok, Err>` (where `Err = A \| B`)            | Sum result. Each variant carries its declared payload. |
+| `unit`                                             | The target's unit type.                           |
+
+Identity types (`type Id ...`): generate an opaque wrapper so an `UserId`
+cannot be passed where a `BookingId` is expected.
+
+### `invariant`
+
+| Form                              | Emission contract                                 |
+|-----------------------------------|---------------------------------------------------|
+| Actor-local predicate             | Check before every `commit` in that actor.        |
+| System-wide prose invariant       | Generate a documented test asserting the invariant. Refuse to silently skip. |
+
+### `prose`
+
+The feature's interface block. Drive module structure from it.
+
+| `prose:` field   | Emission contract                                          |
+|------------------|------------------------------------------------------------|
+| `intent:`        | Module-level docstring/comment header.                     |
+| `exports:`       | The module's public surface. Anything not exported is private. |
+| `uses:`          | Cross-feature imports + external SDK adapters.             |
+| `policies:`      | Apply the listed policies at every controller and flow in the feature. |
+
+`uses: feature X for OpName` resolves to feature `X`'s `exports:` list.
+If `OpName` is not in `X`'s exports, generation fails with a clear error.
+
+### `target`
+
+`target <name> { ... }` blocks live in `preferences.candy`. They are
+hints, not constraints. See §1 "Reading `preferences.candy`".
+
+---
+
+## 3. Policy attachment
+
+The `policies:` field declares **where** a policy is enforced. Five valid
+attachment points, increasing in scope:
+
+| Scope        | Attachment                                                      | Emission                                                  |
+|--------------|------------------------------------------------------------------|-----------------------------------------------------------|
+| Type         | Inside a `type` block.                                          | Run policy at every value construction.                   |
+| Actor        | Inside an `actor` block.                                        | Wrap every `accepts` handler.                             |
+| Flow         | Inside a `flow` block.                                          | Run policy as a precondition before the first step.       |
+| Controller   | Inside a `controller` block (or per-route).                     | Middleware before route dispatch.                         |
+| Feature      | Inside a `prose` block.                                         | Apply to every controller and flow inside the feature.    |
+
+Generated code must make every attachment point explicit and grep-able.
+Do not hide policy enforcement inside a base class or dynamic registry —
+each enforcement site shows the policy by name in source.
+
+---
+
+## 4. Cross-cutting rules (universal — overrides any per-target idiom)
+
+| Rule | Why |
+|------|-----|
+| Money is integer minor units. **No floats anywhere money flows.** | Avoid `0.1 + 0.2 = 0.30000000000000004` and similar. |
+| `now: Timestamp` is an input parameter. Never read a global clock. | Determinism, testability, replay. |
+| Idempotency keys are explicit. Every replayable message accepts `key: Key`. Replay returns the prior result; effects do not run twice. | Safety under retries. |
+| One actor owns its state. No other actor reads or writes that state directly. Cross-actor mutation goes through a `flow`. | Locality of reasoning, isolation. |
+| Time is UTC; durations write `7d`, `10m`, `1h`, `30s`, `500ms`. Arithmetic: `now after 7d`, `expires before now`. | Single tz, single shape. |
+| Every `Result<Ok, A \| B \| C>` variant is reachable. Every declared error must be possible to produce in tests. Dead variants are a generation error. | Errors are part of the contract, not stubs. |
+| `audit name { ... }` is append-only. Generated writes never `UPDATE` audit rows. | Audit means audit. |
+| `derive` is computed; never persisted. | One source of truth. |
+| `subscribe X -> Y` makes Y idempotent if X has `delivery: eager`. | At-least-once requires idempotent subscribers. |
+
+If a target's chosen library fights any of these rules, you change the
+library, not the rule. (Example: a JSON encoder that emits floats for
+integer minor-unit money is not acceptable. Pick another, or wrap it.)
+
+---
+
+## 5. Reserved primitives
+
+These functions are available without import:
+
+| Function           | Returns                                              |
+|--------------------|------------------------------------------------------|
+| `generate()`       | A new id of the contextually expected type.          |
+| `hash(value)`      | A hash of `value` using the target's chosen hash library. |
+| `verify(v, h)`     | Verifies `v` against hash `h`.                       |
+| `sum(list)`        | Sum of a list of numbers (int/decimal, branded or unbranded). |
+| `length(list)`     | Cardinality.                                         |
+| `last(list)`       | Last element; rejects empty list.                    |
+| List operators     | `where <predicate>`, `+` (append), `[id]` (index by id field). |
+
+`sum`, `length`, `last` apply to lists of any numeric type, including
+branded ones (`[Money]` works). Implement them per target without
+breaking the type brand.
+
+`generate()`'s id type is inferred from the assignment target. When the
+spec writes `step booking_id = generate()` and uses `booking_id` as a
+`BookingId`, generated code constructs a `BookingId`.
+
+**Race-condition trap**: when a flow refers to a generated id in both
+its happy-path and a `rescue` path, the id must be generated **once** at
+the top of the flow and reused — never re-called. (M1 caught a real bug
+where `PlaceBooking` re-called `generate()` in its rescue path and
+released the wrong booking. Don't repeat that.)
+
+---
+
+## 6. Webhooks
+
+When an `external actor` declares `emits SomeEvent { ... }`, codegen
+produces:
+
+1. An inbound HTTP route at a conventional path (overlay-specified).
+2. Signature verification against the provider's webhook secret (read
+   from `config:`).
+3. Payload mapping from the provider's wire shape to the declared
+   `emits` event shape.
+4. Dispatch to every `subscribe SomeEvent -> ...` handler in the
+   project.
+
+The spec does **not** declare controller routes for webhooks. If you see
+a `controller` block with a route that maps to a webhook handler, that
+is a spec error — refuse and report.
+
+For multi-provider externals, each provider's wire shape is mapped to
+the same declared `emits` event. Generated code dispatches via the
+provider tag (Stripe payload → `Payments[Stripe]` binding's mapper).
+
+---
+
+## 7. Project layout in the generated tree
+
+The generated tree under `targets/<lang>/` mirrors the spec's feature
+structure plus per-target boilerplate.
+
+```
+targets/<lang>/
+  README.md                   — how to run; what was generated; from which spec commit.
+  <build-manifest>            — go.mod / Cargo.toml / package.json / pyproject.toml.
+  <project-source-root>/
+    <feature>/                — one subdirectory per feature in the spec.
+      ...                     — actor, flow, controller, policy implementations.
+    shared/                   — types, events, invariants common across features.
+    runtime/                  — the substrate (DB pool, scheduler, event bus).
+    main entry point          — wires everything together.
+  test/                       — integration tests; can run hurl against the binary.
+```
+
+Every generated source file starts with a header line naming:
+
+- The spec source path it was generated from (e.g. `// generated from spec/auth/auth.candy`).
+- The candy runtime version from `candy.toml`.
+- A "do not edit" notice; humans regenerate, they do not edit.
+
+---
+
+## 8. Conformance gate — your output is judged by hurl
+
+`evals/<feature>/<feature>.hurl` is the behavioural contract. Every
+declared behaviour must be reachable. Concretely:
+
+- Every `controller`'s every `ok(...) -> Status` is exercised by at
+  least one happy-path scenario. Generated code must hit that exact
+  status with that exact body shape.
+- Every `err(Variant) -> Status` is exercised. Generated code must map
+  that exact variant to that exact status.
+- Auth-required routes return 401 on missing/invalid bearer.
+- Role-gated routes return 403 on wrong role.
+- Replayable flows declaring `key: Key` return identical responses on
+  identical-key replay.
+- State preconditions are exercised both ways (e.g. verify-already-
+  verified → 409). Generated code must produce the declared error
+  variant in the declared case.
+- Compensation paths are tested when the failure point is mockable.
+  Generated code must make the compensating call when its declared
+  step rejects.
+- Schedule predicates are tested by setting up matching state and
+  sleeping past the cadence. Generated schedulers must fire the flow.
+
+If your code passes the relevant `.hurl`, the spec was implemented
+correctly. If it fails, the diff between observed and asserted is your
+bug list.
+
+---
+
+## 9. Determinism and regeneration
+
+Generated code is fully owned by the codegen. Humans do not edit
+`targets/<lang>/`. When the spec changes:
+
+1. Regenerate the target.
+2. Run the hurl conformance suite.
+3. Commit the regenerated tree.
+
+Generation is not required to be byte-identical across runs — but
+arbitrary churn is a smell. Use stable orderings (alphabetical by name
+for declarations, source order for scopes). Do not embed timestamps in
+generated source.
+
+---
+
+## 10. What to refuse
+
+Refuse to generate, with a clear error, when:
+
+| Condition                                                                                       |
+|-------------------------------------------------------------------------------------------------|
+| The spec uses a syntax not described in `GRAMMAR.md`.                                           |
+| Both `<name>/prose.candy` and `<name>.candy` exist (ambiguous feature layout).                  |
+| A `uses: feature X for Op` references an `Op` not in `X`'s `exports:`.                          |
+| A `flow`'s compensation chain references an actor with no compensating message declared.        |
+| A `subscribe X -> Y` requires idempotency (X is `delivery: eager`) but Y has no `key: Key`.     |
+| A multi-provider external references a tag with no `config <Tag>:` block.                       |
+| A `controller` route maps to a webhook handler (webhook routes are codegen-derived; not in spec). |
+| A `type` declares `float` as its underlying primitive (money rule).                             |
+| Any required field on a block is missing per `GRAMMAR.md`.                                      |
+
+When refusing, name the file and line of the offending construct, name
+the rule, and stop. Do not emit partial output.
+
+---
+
+## 11. Style notes — universal
+
+- **Names**: preserve identifiers from the spec. `BookingId` in the spec
+  is `BookingId` in the code. No transliteration to snake_case unless
+  the target's idiom demands it (Go: types `BookingId`, fields
+  `booking_id`; Python: type `BookingId`, fields `booking_id`; Rust:
+  type `BookingId`, fields `booking_id`; TS: type `BookingId`, fields
+  `bookingId`).
+- **Comments**: short. The spec block's `intent:` is the docstring.
+  Don't restate what the code does; explain why if and only if the spec
+  doesn't.
+- **Imports**: only what's used. Never grep-bait.
+- **Tests**: every `policy` block's `examples:` translates to a unit
+  test; every `controller`'s every `ok`/`err` mapping is reachable from
+  the hurl scenarios.
+
+---
+
+## 12. Sequence — how to actually generate
+
+For a project with N features and T targets, the order is:
+
+1. Read `candy.toml`. Identify targets.
+2. Read `preferences.candy`. Build per-target preference maps.
+3. Walk the spec. Build a global symbol table:
+   - All declared types, enums, events, policies, actors, externals,
+     flows, controllers, schedules.
+   - Per-feature `prose` exports/uses graph.
+4. Validate the spec against §10. If anything fails, refuse.
+5. For each target:
+   1. Load the target overlay.
+   2. Dispatch to the language-best-practices skill if the overlay
+      names one.
+   3. Emit the runtime substrate (DB pool, scheduler, event bus, HTTP
+      framework wiring).
+   4. Emit shared types, enums, events.
+   5. Per feature, emit actors → flows → controllers → policies, in
+      dependency order.
+   6. Emit `main` (or equivalent) wiring everything together.
+   7. Emit test scaffolding (policy-example tests, hurl runner).
+6. Run the target's lint/format tooling. Fix any issue before reporting
+   the generation done.
+
+---
+
+## 13. Out of scope for v0.1
+
+- Database migrations beyond the initial schema (no incremental migrations yet).
+- Multi-region / multi-tenant routing.
+- Authorization beyond `auth: bearer | basic | none` and policy-based RBAC.
+- Streaming responses.
+- GraphQL or any non-REST surface.
+- Cryptographic key rotation.
+
+When the spec needs any of these, refuse and report. Don't half-generate.
+
+---
+
+## Reference
+
+- `GRAMMAR.md` — language reference.
+- `evals/README.md` — conformance contract.
+- `docs/architecture.md` — substrate vs spec layering.
+- `docs/externals.md` — external actor pattern, webhooks-as-events.
+- `docs/features.md` — feature layout detection.
+- `docs/candy-toml.md` — manifest schema.

--- a/prompts/codegen-go.md
+++ b/prompts/codegen-go.md
@@ -1,0 +1,301 @@
+# candy codegen — Go overlay
+
+Apply on top of `codegen-base.md`. Before emitting any Go, **load the
+`golang-best-practices` skill** for idiom guidance (concurrency, error
+wrapping, package layout, generics use). This overlay specifies only the
+candy-to-Go bindings.
+
+Default framework: `chi` (HTTP). Default DB: per `preferences.candy`;
+typical is `sqlite` via `mattn/go-sqlite3` for examples, swappable.
+
+---
+
+## Project layout
+
+```
+targets/go/
+  go.mod
+  go.sum
+  cmd/
+    server/main.go               — wires DI, scheduler, HTTP server.
+  internal/
+    <feature>/
+      actors.go                  — actor structs + handlers.
+      flows.go                   — flow functions.
+      controllers.go             — chi routes.
+      policies.go                — policy functions.
+      events.go                  — event types + subscribers.
+    shared/
+      types.go                   — branded types.
+      events.go                  — cross-feature events.
+      errors.go                  — declared error variants (typed).
+    runtime/
+      db.go                      — connection pool.
+      scheduler.go               — schedule executor.
+      eventbus.go                — event delivery.
+      webhooks.go                — webhook signature verification helpers.
+  test/
+    integration_test.go          — hurl runner harness (shells out).
+```
+
+Module path: `github.com/<owner>/<project>` if known; otherwise infer
+from `candy.toml`'s `[project].name` and emit a `// TODO: set module
+path` comment in `go.mod`.
+
+---
+
+## Block-by-block bindings
+
+### `actor`
+
+```go
+type Booking struct {
+    ID     BookingId
+    Status BookingStatus
+    // ... one field per state entry, exported.
+}
+
+type BookingRepo struct{ db *sql.DB }
+
+func (r *BookingRepo) Create(ctx context.Context, init BookingInit) (*Booking, error) { ... }
+func (r *BookingRepo) FindByID(ctx context.Context, id BookingId) (*Booking, error)   { ... }
+// One method per `accepts`:
+func (r *BookingRepo) Confirm(ctx context.Context, id BookingId, args ConfirmArgs, now time.Time, key IdempotencyKey) (ConfirmOk, error) { ... }
+```
+
+- One package per feature under `internal/<feature>/`.
+- State persists via the chosen DB library; the `<Actor>Repo` struct
+  owns reads/writes for that actor's table only.
+- `derive` accessors are methods on the actor struct (computed each
+  call; never stored).
+- `invariant` predicates run before commit; failure returns a typed
+  error.
+- `audit` is an append-only sibling table; emitted via an `audit*`
+  method; the audit method never updates rows.
+
+### `external actor`
+
+```go
+type Payments interface {
+    Charge(ctx context.Context, amt Money, src PaymentMethod, key IdempotencyKey) (ChargeId, error)
+}
+
+// One implementation per declared provider tag.
+type stripePayments struct{ client *stripe.Client }
+func NewStripePayments(secret string) Payments { ... }
+```
+
+- Multi-provider: emit `type Payments interface { ... }` plus one
+  implementation per tag. A registry maps tag → implementation.
+- Webhook routes are emitted at `/webhooks/<provider>/<event>` (e.g.
+  `/webhooks/stripe/charge-succeeded`); the body is the provider's
+  native payload. Verify signature, map to declared `emits` event,
+  dispatch to subscribers.
+
+### `flow`
+
+A function returning `(Ok, error)`. Steps are sequential await calls.
+Compensation:
+
+```go
+func PlaceBooking(ctx context.Context, deps Deps, args PlaceBookingArgs, now time.Time, key IdempotencyKey) (BookingConfirmed, error) {
+    bookingId := BookingId(deps.Generate())            // pre-generated; see base §5.
+    held, err := deps.Listings.HoldDates(ctx, args.ListingId, args.Range, bookingId, now)
+    if err != nil { return BookingConfirmed{}, ErrHoldFailed }
+    paid, err := deps.Payments.Charge(ctx, args.Amount, args.Source, key)
+    if err != nil {
+        _ = deps.Listings.ReleaseDates(ctx, held)      // compensate.
+        return BookingConfirmed{}, ErrPaymentDeclined
+    }
+    // ...
+    return BookingConfirmed{ID: bookingId, Charge: paid}, nil
+}
+```
+
+- Pass dependencies as a `Deps` struct or via a constructor closure.
+  No globals.
+- `tell` (fire-and-forget) → spawn a goroutine; do not await.
+- Errors are typed sum variants (see §errors).
+
+### `controller`
+
+```go
+func MountAuth(r chi.Router, deps Deps) {
+    r.Post("/signup", handleSignup(deps))
+    r.Group(func(r chi.Router) {
+        r.Use(BearerAuth(deps))
+        r.Post("/logout", handleLogout(deps))
+    })
+}
+
+func handleSignup(deps Deps) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        var body SignupBody
+        if err := decode(r, &body); err != nil { writeError(w, 400, "bad_request"); return }
+        out, err := Signup(r.Context(), deps, body, time.Now().UTC(), readIdemKey(r))
+        // map exact ok/err to declared status + body shape.
+    }
+}
+```
+
+- One handler per route. Handlers parse → validate → dispatch → map.
+- `auth: bearer` middleware: extracts the bearer token, validates per
+  the `BearerAuth` policy in spec, sets the principal id on context;
+  401 on absent/invalid.
+- `now := time.Now().UTC()` at the boundary; never inside business
+  logic.
+- Idempotency-Key header → `IdempotencyKey` type; passed into the
+  flow.
+
+### `policy`
+
+A free function with `Result`-style return:
+
+```go
+func PasswordStrength(p Password) error {
+    if len(p) < 12 { return ErrWeakPassword }
+    return nil
+}
+```
+
+For policies attached at `controller` scope, emit middleware. For
+`actor`/`flow`/`type` scope, emit a wrapped call before the protected
+operation. For `prose` scope, apply at every controller and flow in
+the feature.
+
+### `event` and subscribe
+
+```go
+type ChargeSucceeded struct {
+    Charge ChargeId
+    At     time.Time
+}
+
+type EventBus interface {
+    Publish(ctx context.Context, ev any) error
+    Subscribe(eventType reflect.Type, h func(ctx context.Context, ev any) error)
+}
+```
+
+- `delivery: eager` — at-least-once. Subscribers must be idempotent.
+- `delivery: strict` — transactional outbox: write event in same tx as
+  the state change, deliver on commit, mark delivered.
+- `delivery: weak` — best-effort goroutine; drop on failure.
+
+### `type` and `enum`
+
+```go
+type Money int64                                    // unit: minor; currency carried separately.
+type Email string                                   // validated at construction by NewEmail.
+type Password string                                // validated by PasswordStrength policy.
+type BookingId string
+
+type BookingStatus int
+const (
+    BookingPending BookingStatus = iota
+    BookingConfirmed
+    BookingCancelled
+)
+```
+
+- Branded primitives → named scalars. Constructors validate when the
+  type has format/max constraints.
+- `Money` is `int64`; never `float64`.
+- `decimal` types use `github.com/shopspring/decimal`.
+- `instant { tz: utc }` → `time.Time` always converted with `.UTC()`.
+- `Result<Ok, Err>` → `(Ok, error)` with typed sentinel errors. Use
+  `errors.Is` for variant checks.
+
+### `schedule`
+
+```go
+// In runtime/scheduler.go a cron-like ticker; on each fire:
+func runChargeCycle(ctx context.Context, deps Deps, now time.Time) {
+    subs, _ := deps.Subscriptions.QueryActive(ctx)
+    for _, sub := range subs {
+        _, _ = ChargeCycle(ctx, deps, sub, now)
+    }
+}
+```
+
+- Default scheduler: a goroutine ticking at the lowest declared
+  cadence; finer-grained schedules use their own ticker. `preferences.candy`
+  may override via `when need scheduler use <library>`.
+- One-shot schedules (`at <expr> for any X in Y where ...`) use a
+  per-instance computed firing time persisted in a `scheduled_jobs`
+  table; the runtime sweeps it at the smallest declared interval.
+
+---
+
+## Errors
+
+Generate one typed sentinel per declared error variant:
+
+```go
+var (
+    ErrWeakPassword       = errors.New("weak_password")
+    ErrEmailAlreadyTaken  = errors.New("email_already_taken")
+    ErrPaymentDeclined    = errors.New("payment_declined")
+)
+```
+
+Each `controller` `err(Variant) -> Status { ... }` mapping uses
+`errors.Is(err, ErrXxx)` to dispatch, then writes the declared body
+shape.
+
+For variants with payload (`err(BadRange { reason })`), wrap with a
+struct error:
+
+```go
+type BadRangeErr struct{ Reason string }
+func (e *BadRangeErr) Error() string { return "bad_range: " + e.Reason }
+```
+
+---
+
+## Runtime substrate
+
+- HTTP: `chi`. Mount per-feature subrouters under their conventional
+  path prefix (`/auth`, `/bookings`, ...).
+- DB: per `preferences.candy`. Default for examples: `sqlite3` via
+  `database/sql` + `github.com/mattn/go-sqlite3`. Schema generated
+  once at startup; no migration framework in v0.1.
+- JWT: per `preferences.candy`. Default: `github.com/golang-jwt/jwt/v5`.
+- Hash: per preferences. Default: `golang.org/x/crypto/argon2`.
+- ID generation: per preferences. Default: `github.com/segmentio/ksuid`.
+- Logging: `log/slog` (structured).
+- Context: `context.Context` is the first parameter of every exported
+  function that crosses an I/O boundary.
+
+---
+
+## Conventions
+
+- Package per feature; package name = lowercase feature name.
+- File per block category (`actors.go`, `flows.go`, ...). Multiple
+  small files beat one large file when a feature has > 5 actors / > 5
+  flows.
+- Field naming: lowerCamelCase for unexported, UpperCamelCase for
+  exported. `BookingId`/`bookingId`; `UserId`/`userId`. Match Go
+  vet's view of acronyms (`ID` not `Id`) where the ID type is
+  Go-native; for spec types named `BookingId` keep that exact spelling
+  to round-trip with the spec.
+- `gofmt -s` clean. `go vet ./...` clean. `golangci-lint run` clean
+  if a config exists.
+
+---
+
+## Verification before reporting done
+
+```sh
+cd targets/go
+go vet ./...
+go build ./...
+go test ./...
+hurl --variables-file ../../evals/<feature>/fixtures.env \
+     --variable BASE_URL=http://localhost:8080 \
+     ../../evals/<feature>/<feature>.hurl
+```
+
+All four must pass. If a hurl scenario fails, the spec mapping is wrong
+or the runtime substrate is wrong — do not edit the hurl.

--- a/prompts/codegen-python.md
+++ b/prompts/codegen-python.md
@@ -1,0 +1,271 @@
+# candy codegen — Python overlay
+
+Apply on top of `codegen-base.md`. Default framework: `fastapi` (HTTP).
+Default Python: 3.11+. Default async runtime: `asyncio` via uvicorn.
+
+There is no `python-best-practices` skill in v0.1, so this overlay
+carries more inline idiom than Go and Rust.
+
+---
+
+## Project layout
+
+```
+targets/python/
+  pyproject.toml               — uv or pip-installable; ruff + mypy config.
+  src/
+    main.py                    — FastAPI app + uvicorn entry.
+    <project>/
+      __init__.py
+      <feature>/
+        __init__.py
+        actors.py
+        flows.py
+        controllers.py
+        policies.py
+        events.py
+      shared/
+        types.py
+        events.py
+        errors.py
+      runtime/
+        db.py
+        scheduler.py
+        event_bus.py
+        webhooks.py
+  tests/
+    test_integration.py        — hurl runner harness.
+```
+
+Package layout uses a single distribution package named after
+`candy.toml`'s `[project].name`.
+
+---
+
+## Block-by-block bindings
+
+### `actor`
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Booking:
+    id: BookingId
+    status: BookingStatus
+    # one field per state entry; frozen where mutation is not modelled.
+
+class BookingRepo:
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def create(self, init: BookingInit) -> Booking: ...
+    async def find_by_id(self, id: BookingId) -> Booking | None: ...
+    async def confirm(
+        self, id: BookingId, args: ConfirmArgs, now: Timestamp, key: IdempotencyKey,
+    ) -> Result[ConfirmOk, ConfirmErr]: ...
+```
+
+- One module per feature; one repo class per actor.
+- `derive` accessors are `@property` getters (computed each call).
+- `invariant` predicates raise a declared exception before commit.
+- `audit` tables are append-only.
+
+### `external actor`
+
+```py
+from typing import Protocol
+
+class Payments(Protocol):
+    async def charge(self, amount: Money, source: PaymentMethod, key: IdempotencyKey) \
+        -> Result[ChargeId, PaymentError]: ...
+
+class StripePayments:
+    def __init__(self, client: stripe.Client) -> None: ...
+    async def charge(self, ...): ...
+```
+
+- Multi-provider: `Protocol` + one class per tag; a `dict[Tag, Payments]`
+  registry in `runtime/`.
+- Webhook routes: `POST /webhooks/{provider}/{event}`. Verify signature
+  via the provider's library, map payload to the declared `emits`
+  event, dispatch.
+
+### `flow`
+
+```py
+async def place_booking(
+    deps: Deps,
+    args: PlaceBookingArgs,
+    now: Timestamp,
+    key: IdempotencyKey,
+) -> Result[BookingConfirmed, BookingError]:
+    booking_id = BookingId.generate()                # pre-generated; base §5.
+    held = await deps.listings.hold_dates(args.listing_id, args.range, booking_id, now)
+    if held.is_err(): return Err(BookingError.HOLD_FAILED)
+    paid = await deps.payments.charge(args.amount, args.source, key)
+    if paid.is_err():
+        await deps.listings.release_dates(held.unwrap())     # compensate.
+        return Err(BookingError.PAYMENT_DECLINED)
+    return Ok(BookingConfirmed(id=booking_id, charge=paid.unwrap()))
+```
+
+- Use a result-like `Result[T, E]` (e.g. `returns.Result` from the
+  `returns` library, or a small in-project implementation). Don't
+  raise for declared errors.
+- `tell` (fire-and-forget): `asyncio.create_task(...)` without
+  awaiting; ensure the runtime captures unhandled-task exceptions.
+
+### `controller`
+
+```py
+from fastapi import APIRouter, Depends, HTTPException, Header, Request
+
+router = APIRouter()
+
+@router.post('/signup', status_code=201)
+async def handle_signup(body: SignupBody, request: Request) -> SignupResponse:
+    now = Timestamp.now_utc()
+    key = read_idem_key(request.headers)
+    result = await signup(deps, body, now, key)
+    match result:
+        case Ok(value):                              return value
+        case Err('weak_password'):                   raise HTTPException(400, detail='weak_password')
+        case Err('email_taken'):                     raise HTTPException(409, detail='email_taken')
+```
+
+- One handler per route. Pydantic models for request/response shape.
+- `auth: bearer` → a `Depends(...)` that extracts and validates the
+  token; raises `HTTPException(401)` on missing/invalid.
+- `now` is captured at the boundary.
+
+### `policy`
+
+```py
+def password_strength(p: Password) -> Result[None, str]:
+    if len(p) < 12:
+        return Err('weak_password')
+    return Ok(None)
+```
+
+- `controller`-scope policies → FastAPI dependencies.
+- `actor`/`flow`/`type` scope: explicit call before the protected op.
+
+### `event`
+
+```py
+@dataclass(frozen=True)
+class ChargeSucceeded:
+    charge: ChargeId
+    at: Timestamp
+
+class EventBus(Protocol):
+    async def publish(self, ev: object) -> None: ...
+    def subscribe(self, event_type: type, h: Callable[[object], Awaitable[None]]) -> None: ...
+```
+
+- `delivery: strict` → transactional outbox.
+- `delivery: eager` → at-least-once via Celery, RQ, or NATS per
+  preferences.
+- `delivery: weak` → `asyncio.create_task` with a global error logger.
+
+### `type` and `enum`
+
+```py
+from typing import NewType, Literal
+
+Money    = NewType('Money', int)                    # integer minor units.
+Email    = NewType('Email', str)
+BookingId = NewType('BookingId', str)
+
+class BookingStatus(str, Enum):
+    PENDING   = 'pending'
+    CONFIRMED = 'confirmed'
+    CANCELLED = 'cancelled'
+
+# Result type:
+@dataclass(frozen=True)
+class Ok(Generic[T]):  value: T
+@dataclass(frozen=True)
+class Err(Generic[E]): error: E
+Result = Ok[T] | Err[E]
+```
+
+- **Money is `int`** (minor units). Floats are forbidden.
+- `decimal` types use `decimal.Decimal`; never `float`.
+- `instant { tz: utc }` → `datetime.datetime` with `tzinfo=timezone.utc`.
+  Build a small `Timestamp` wrapper alias.
+- Sum errors: string-literal `Literal[...]` types or `Enum`.
+- Validators (for `format`/`max`): construct via `parse` factory
+  functions that return `Result`.
+
+### `schedule`
+
+```py
+async def run_charge_cycle(deps: Deps, now: Timestamp) -> None:
+    subs = await deps.subscriptions.query_active()
+    for sub in subs:
+        await charge_cycle(deps, sub, now)
+
+# In runtime/scheduler.py: APScheduler or asyncio-based cron.
+```
+
+- Default scheduler library: `APScheduler` (per preferences). One-shot
+  schedules persist firing times in `scheduled_jobs`; the runtime
+  sweeps on the smallest declared interval.
+
+---
+
+## Errors
+
+Declared error variants are `Literal` strings or `Enum` members. Don't
+raise for declared errors — flow them through `Result`. Reserved for
+unexpected runtime failures: `Exception` subclasses logged at the
+boundary.
+
+---
+
+## Runtime substrate
+
+- HTTP: `fastapi` + `uvicorn`.
+- DB: per preferences. Default examples: `sqlite3` (stdlib) or
+  `aiosqlite`. Production swaps to `asyncpg` + `sqlalchemy` 2.0 async.
+- JWT: per preferences. Default: `pyjwt`.
+- Hash: per preferences. Default: `argon2-cffi`.
+- ID: per preferences. Default: `python-ulid`.
+- Logging: `structlog` or stdlib `logging`.
+- Validation: `pydantic` v2 for request/response models.
+
+---
+
+## Conventions
+
+- Python 3.11+. Use `from __future__ import annotations` only when
+  necessary; PEP 604 union syntax (`A | B`) is the default.
+- Spec identifier `BookingId` → Python `BookingId`; spec field
+  `booking_id` → Python field `booking_id` (snake_case fields per PEP 8).
+- `mypy --strict` clean (or `pyright` strict).
+- `ruff check .` clean. `ruff format .` clean.
+- No `Any` outside well-marked boundaries (e.g., raw provider payloads
+  before mapping).
+- Type-hint every public function. `from __future__ import annotations`
+  is fine but inferable types are preferred.
+
+---
+
+## Verification before reporting done
+
+```sh
+cd targets/python
+uv sync                          # or: pip install -e '.[dev]'
+ruff check .
+ruff format --check .
+mypy src
+pytest
+uvicorn src.main:app --port 8000 &
+hurl --variables-file ../../evals/<feature>/fixtures.env \
+     --variable BASE_URL=http://localhost:8000 \
+     ../../evals/<feature>/<feature>.hurl
+```
+
+All six must pass. Don't edit hurl files to make them green.

--- a/prompts/codegen-rust.md
+++ b/prompts/codegen-rust.md
@@ -1,0 +1,292 @@
+# candy codegen — Rust overlay
+
+Apply on top of `codegen-base.md`. Before emitting any Rust, **load the
+`rust-best-practices` skill** for idiom guidance (ownership, error types,
+async runtime patterns, trait design). This overlay specifies only the
+candy-to-Rust bindings.
+
+Default framework: `axum` (HTTP). Default async runtime: `tokio`.
+Default DB: per `preferences.candy`; typical is `rusqlite` for examples,
+swappable to `sqlx` + Postgres in production.
+
+---
+
+## Project layout
+
+```
+targets/rust/
+  Cargo.toml
+  src/
+    main.rs                     — tokio runtime, DI, server bootstrap.
+    lib.rs                      — re-exports.
+    <feature>/
+      mod.rs
+      actors.rs
+      flows.rs
+      controllers.rs
+      policies.rs
+      events.rs
+    shared/
+      types.rs                  — branded types.
+      events.rs                 — cross-feature events.
+      errors.rs                 — declared error variants.
+    runtime/
+      db.rs
+      scheduler.rs
+      event_bus.rs
+      webhooks.rs
+  tests/
+    integration.rs              — hurl runner harness.
+```
+
+Crate name: `<project_name>`. Edition 2021.
+
+---
+
+## Block-by-block bindings
+
+### `actor`
+
+```rust
+pub struct Booking {
+    pub id: BookingId,
+    pub status: BookingStatus,
+    // one field per state entry.
+}
+
+pub struct BookingRepo { pool: sqlx::Pool<sqlx::Sqlite> }
+
+impl BookingRepo {
+    pub async fn create(&self, init: BookingInit) -> Result<Booking, ActorError> { ... }
+    pub async fn find_by_id(&self, id: BookingId) -> Result<Booking, ActorError> { ... }
+    pub async fn confirm(&self, id: BookingId, args: ConfirmArgs, now: Timestamp, key: IdempotencyKey)
+        -> Result<ConfirmOk, ConfirmErr> { ... }
+}
+```
+
+- One module per feature.
+- The `<Actor>Repo` owns reads/writes for that actor's table only.
+- `derive` accessors are `impl` methods returning the computed value.
+- `invariant` predicates: enforce in the repo function before commit;
+  return a typed error variant on violation.
+- `audit` tables: append-only, no `UPDATE`.
+
+### `external actor`
+
+```rust
+#[async_trait]
+pub trait Payments: Send + Sync {
+    async fn charge(&self, amt: Money, src: PaymentMethod, key: IdempotencyKey)
+        -> Result<ChargeId, PaymentError>;
+}
+
+pub struct StripePayments { client: stripe::Client }
+
+#[async_trait]
+impl Payments for StripePayments { ... }
+```
+
+- Multi-provider: trait + one impl per tag. A registry HashMap maps
+  tag → `Arc<dyn Payments>`.
+- Webhook routes: `POST /webhooks/<provider>/<event>`. Verify
+  signature using the provider's library, map payload to the declared
+  `emits` event, dispatch.
+
+### `flow`
+
+```rust
+pub async fn place_booking(
+    deps: &Deps,
+    args: PlaceBookingArgs,
+    now: Timestamp,
+    key: IdempotencyKey,
+) -> Result<BookingConfirmed, BookingError> {
+    let booking_id = BookingId::generate();              // pre-generated; base §5.
+    let held = deps.listings.hold_dates(args.listing_id, args.range, booking_id, now)
+        .await
+        .map_err(|_| BookingError::HoldFailed)?;
+    let paid = match deps.payments.charge(args.amount, args.source, key).await {
+        Ok(p) => p,
+        Err(_) => {
+            let _ = deps.listings.release_dates(held).await;     // compensate.
+            return Err(BookingError::PaymentDeclined);
+        }
+    };
+    Ok(BookingConfirmed { id: booking_id, charge: paid })
+}
+```
+
+- `tell` (fire-and-forget): `tokio::spawn` the call; do not await.
+- Compensation: explicit; on rejection, run named-step compensators in
+  reverse, then return the error variant.
+- Dependencies: pass `&Deps` (borrowed) or `Arc<Deps>` if cloned across
+  threads.
+
+### `controller`
+
+```rust
+pub fn auth_router(deps: Arc<Deps>) -> Router {
+    Router::new()
+        .route("/signup", post(handle_signup))
+        .route("/logout", post(handle_logout).layer(BearerAuth::layer(deps.clone())))
+        .with_state(deps)
+}
+
+async fn handle_signup(
+    State(deps): State<Arc<Deps>>,
+    headers: HeaderMap,
+    Json(body): Json<SignupBody>,
+) -> Response {
+    let now = Timestamp::now_utc();
+    let key = read_idem_key(&headers);
+    match signup(&deps, body, now, key).await {
+        Ok(out) => (StatusCode::CREATED, Json(out)).into_response(),
+        Err(SignupError::WeakPassword) => bad_request("weak_password"),
+        Err(SignupError::EmailTaken)   => conflict("email_taken"),
+    }
+}
+```
+
+- One async function per route.
+- `Json(body)` validates via `serde` + `validator` if a `body` shape
+  declares constraints.
+- `auth: bearer` → an extractor or middleware layer that yields the
+  authenticated principal id; 401 on missing/invalid.
+- Map every declared `ok(...)` and `err(Variant)` to its declared
+  status with its declared body shape.
+
+### `policy`
+
+Pure function; preconditions return `Result<(), PolicyError>`:
+
+```rust
+pub fn password_strength(p: &Password) -> Result<(), AuthError> {
+    if p.0.len() < 12 { return Err(AuthError::WeakPassword); }
+    Ok(())
+}
+```
+
+`controller`-scope policies become `tower` middleware layers.
+`actor`/`flow` scope: explicit call before the protected op.
+`prose` scope: apply at every controller and flow in the feature.
+
+### `event`
+
+```rust
+#[derive(Clone, Debug)]
+pub struct ChargeSucceeded {
+    pub charge: ChargeId,
+    pub at: Timestamp,
+}
+
+pub trait EventBus: Send + Sync {
+    fn publish(&self, ev: BoxedEvent) -> impl Future<Output = Result<(), BusError>> + Send;
+    fn subscribe<E: 'static>(&self, h: impl Fn(E) -> BoxFuture<'static, Result<(), BusError>> + Send + Sync + 'static);
+}
+```
+
+- `delivery: strict` → transactional outbox via the same DB
+  connection.
+- `delivery: eager` → at-least-once channel (`tokio::sync::broadcast`
+  for in-process; out-of-process needs a queue per preferences).
+- `delivery: weak` → fire-and-forget `tokio::spawn`.
+
+### `type` and `enum`
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct Money(pub i64);                         // unit: minor; currency carried separately.
+
+#[derive(Clone, Debug)]
+pub struct Email(String);
+
+impl Email {
+    pub fn parse(s: impl Into<String>) -> Result<Self, AuthError> { /* validate format/max */ }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BookingStatus { Pending, Confirmed, Cancelled }
+
+pub type BookingResult = Result<BookingConfirmed, BookingError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum BookingError {
+    #[error("hold_failed")]    HoldFailed,
+    #[error("payment_declined")] PaymentDeclined,
+}
+```
+
+- Branded types: newtype struct. `Eq`/`Hash` where the inner allows.
+- `Money`/integer minor units: `i64`.
+- `decimal` types: `rust_decimal::Decimal`.
+- `instant { tz: utc }`: `chrono::DateTime<chrono::Utc>` or
+  `time::OffsetDateTime` (per preferences).
+- Sum errors: `enum` deriving `thiserror::Error`.
+
+### `schedule`
+
+```rust
+async fn run_charge_cycle(deps: Arc<Deps>, now: Timestamp) {
+    let subs = deps.subscriptions.query_active().await.unwrap_or_default();
+    for sub in subs {
+        let _ = charge_cycle(&deps, sub, now).await;
+    }
+}
+
+// Spawn a tokio::time::interval ticker per declared schedule cadence.
+```
+
+- One-shot schedules: store firing time in a `scheduled_jobs` table;
+  the runtime sweeps it on the smallest declared interval.
+
+---
+
+## Errors
+
+`thiserror` for declared variants. `anyhow` only at the binary's outer
+edge (logging unexpected internal failures). Spec-declared variants are
+always typed and exhaustive.
+
+---
+
+## Runtime substrate
+
+- HTTP: `axum` 0.7 + `tower-http`.
+- Async: `tokio` (multi-thread).
+- DB: per preferences. Examples default to `rusqlite` (sync, simple);
+  real apps use `sqlx` async.
+- JWT: per preferences. Default: `jsonwebtoken`.
+- Hash: per preferences. Default: `argon2` crate.
+- ID: per preferences. Default: `uuid` v7 or `ksuid`.
+- Logging: `tracing` + `tracing-subscriber`.
+
+---
+
+## Conventions
+
+- Module per feature. `snake_case` modules, `UpperCamelCase` types,
+  `snake_case` functions/fields.
+- Spec identifier `BookingId` → Rust type `BookingId`; spec field
+  `booking_id` → Rust field `booking_id`.
+- `cargo fmt` clean. `cargo clippy -- -D warnings` clean.
+- No `unwrap()` outside `main.rs` startup or test code. Spec-declared
+  error variants are exhaustive.
+
+---
+
+## Verification before reporting done
+
+```sh
+cd targets/rust
+cargo fmt --all -- --check
+cargo clippy --all -- -D warnings
+cargo build --release
+cargo test
+# server up, then:
+hurl --variables-file ../../evals/<feature>/fixtures.env \
+     --variable BASE_URL=http://localhost:3000 \
+     ../../evals/<feature>/<feature>.hurl
+```
+
+All five must pass. Don't edit hurl files to make them green; the spec
+mapping is the bug.

--- a/prompts/codegen-typescript.md
+++ b/prompts/codegen-typescript.md
@@ -1,0 +1,283 @@
+# candy codegen — TypeScript overlay
+
+Apply on top of `codegen-base.md`. Default framework: `hono` (HTTP).
+Default runtime: Node 20+; ESM only.
+
+There is no `typescript-best-practices` skill in v0.1, so this overlay
+carries more inline idiom than the Go and Rust overlays. The
+`react-best-practices` skill is **not** appropriate — that's a Next.js
+performance skill, not a backend skill. Do not load it.
+
+---
+
+## Project layout
+
+```
+targets/typescript/
+  package.json
+  tsconfig.json                — strict, ESM, target ES2022.
+  src/
+    index.ts                   — Hono app + serve.
+    <feature>/
+      actors.ts
+      flows.ts
+      controllers.ts
+      policies.ts
+      events.ts
+      index.ts                 — re-exports.
+    shared/
+      types.ts
+      events.ts
+      errors.ts
+    runtime/
+      db.ts
+      scheduler.ts
+      eventBus.ts
+      webhooks.ts
+  test/
+    integration.test.ts        — hurl runner harness.
+```
+
+`package.json`: `"type": "module"`; `engines.node >= 20`.
+`tsconfig.json`: `strict: true`, `noUncheckedIndexedAccess: true`,
+`exactOptionalPropertyTypes: true`, `module: ESNext`,
+`moduleResolution: bundler`.
+
+---
+
+## Block-by-block bindings
+
+### `actor`
+
+```ts
+export type Booking = {
+  id: BookingId;
+  status: BookingStatus;
+  // one field per state entry; readonly where the type allows.
+};
+
+export class BookingRepo {
+  constructor(private db: Database) {}
+  async create(init: BookingInit): Promise<Booking> { ... }
+  async findById(id: BookingId): Promise<Booking | null> { ... }
+  async confirm(
+    id: BookingId, args: ConfirmArgs, now: Timestamp, key: IdempotencyKey,
+  ): Promise<Result<ConfirmOk, ConfirmErr>> { ... }
+}
+```
+
+- Module per feature.
+- `<Actor>Repo` class owns reads/writes for that actor's table.
+- `derive` accessors → getter methods or pure functions; never stored.
+- `invariant` predicates → throw a typed error before commit.
+- `audit` tables → append-only.
+
+### `external actor`
+
+```ts
+export interface Payments {
+  charge(amount: Money, source: PaymentMethod, key: IdempotencyKey)
+    : Promise<Result<ChargeId, PaymentError>>;
+}
+
+export class StripePayments implements Payments { ... }
+```
+
+- Multi-provider: interface + one class per tag. A `Map<Tag, Payments>`
+  registry lives in `runtime/`.
+- Webhook routes: `POST /webhooks/:provider/:event`. Verify signature,
+  map payload, dispatch.
+
+### `flow`
+
+```ts
+export async function placeBooking(
+  deps: Deps,
+  args: PlaceBookingArgs,
+  now: Timestamp,
+  key: IdempotencyKey,
+): Promise<Result<BookingConfirmed, BookingError>> {
+  const bookingId = generateBookingId();              // pre-generated; base §5.
+  const held = await deps.listings.holdDates(args.listingId, args.range, bookingId, now);
+  if (!held.ok) return err('hold_failed');
+  const paid = await deps.payments.charge(args.amount, args.source, key);
+  if (!paid.ok) {
+    await deps.listings.releaseDates(held.value);     // compensate.
+    return err('payment_declined');
+  }
+  return ok({ id: bookingId, charge: paid.value });
+}
+```
+
+- Use a `Result<T, E>` discriminated union throughout flows. Don't
+  throw for declared errors; throws are reserved for runtime bugs.
+- `tell` (fire-and-forget): call without `await`; ensure the runtime
+  swallows rejections via a top-level handler.
+
+### `controller`
+
+```ts
+const auth = new Hono<{ Variables: { principalId: UserId } }>();
+
+auth.post('/signup', async (c) => {
+  const body = await c.req.json<SignupBody>();
+  const result = await signup(deps, body, Timestamp.nowUtc(), readIdemKey(c));
+  if (!result.ok) {
+    if (result.error === 'weak_password')  return c.json({ error: 'weak_password' }, 400);
+    if (result.error === 'email_taken')    return c.json({ error: 'email_taken' }, 409);
+  }
+  return c.json(result.value, 201);
+});
+```
+
+- Hono router per feature; mount under conventional path.
+- `auth: bearer` → middleware that extracts and validates the bearer,
+  populates `c.var.principalId`, returns 401 on missing/invalid.
+- `now` is captured at the route boundary; never inside handlers.
+
+### `policy`
+
+Pure function returning `Result<void, ...>`:
+
+```ts
+export function passwordStrength(p: Password): Result<void, 'weak_password'> {
+  if (p.length < 12) return err('weak_password');
+  return ok(undefined);
+}
+```
+
+- `controller`-scope policies are Hono middleware.
+- `actor`/`flow`/`type` scope: explicit call before the protected op.
+
+### `event`
+
+```ts
+export type ChargeSucceeded = {
+  type: 'charge_succeeded';
+  charge: ChargeId;
+  at: Timestamp;
+};
+
+export interface EventBus {
+  publish<E extends EventEnvelope>(ev: E): Promise<void>;
+  subscribe<E extends EventEnvelope>(type: E['type'], h: (ev: E) => Promise<void>): void;
+}
+```
+
+- `delivery: strict` → transactional outbox.
+- `delivery: eager` → at-least-once via the chosen queue (`bullmq`,
+  `bee-queue`, etc.) per preferences.
+- `delivery: weak` → in-process fire-and-forget `Promise`.
+
+### `type` and `enum`
+
+```ts
+// Branded primitives via tagged types:
+declare const __brand: unique symbol;
+export type Money = number & { [__brand]: 'Money' };           // integer minor units.
+export type Email = string & { [__brand]: 'Email' };
+export type BookingId = string & { [__brand]: 'BookingId' };
+
+export const Money = {
+  cents(n: number): Money {
+    if (!Number.isInteger(n)) throw new Error('money_must_be_integer');
+    return n as Money;
+  },
+};
+
+export const Email = {
+  parse(s: string): Result<Email, 'bad_email'> { ... },
+};
+
+export type BookingStatus = 'pending' | 'confirmed' | 'cancelled';
+
+export type Result<T, E> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+export const ok = <T>(v: T): Result<T, never>      => ({ ok: true,  value: v });
+export const err = <E>(e: E): Result<never, E>     => ({ ok: false, error: e });
+```
+
+- **Money is integer cents**, typed as `number & { brand }`. Generated
+  arithmetic preserves the brand. Floats are forbidden.
+- `decimal` types: use `decimal.js` per preferences (`when need decimal use decimal.js`).
+- `instant { tz: utc }` → `Date` always constructed in UTC, plus a
+  `Timestamp` opaque alias for the spec name.
+- Sum errors: string-literal unions for variant names; objects
+  carrying payloads.
+
+### `schedule`
+
+```ts
+// In runtime/scheduler.ts:
+const ticker = setInterval(async () => {
+  const now = Timestamp.nowUtc();
+  const subs = await deps.subscriptions.queryActive();
+  await Promise.allSettled(subs.map((s) => chargeCycle(deps, s, now)));
+}, 30 * 24 * 60 * 60 * 1000);
+```
+
+- For real cadences (60s, 1h, 1d), use `node-cron` or per-target
+  preference. For one-shot schedules, persist firing times in
+  `scheduled_jobs` and sweep on the smallest declared interval.
+
+---
+
+## Errors
+
+Error variants are string-literal types. Each declared variant is a
+tag; payload-bearing variants are objects with a `tag` discriminator.
+Throwing is reserved for runtime bugs (DB unreachable, etc.); declared
+errors flow through `Result`.
+
+```ts
+export type SignupError = 'weak_password' | 'email_taken';
+export type BadRange = { tag: 'bad_range'; reason: string };
+```
+
+---
+
+## Runtime substrate
+
+- HTTP: `hono` + `@hono/node-server`.
+- DB: per preferences. Default examples: `better-sqlite3` (sync) or
+  `node:sqlite` if Node 20+; production swaps to `pg` + `kysely` or
+  `drizzle`.
+- JWT: per preferences. Default: `jsonwebtoken`.
+- Hash: per preferences. Default: `@node-rs/argon2`.
+- ID: per preferences. Default: `cuid2`.
+- Logging: `pino`.
+- Validation: `zod` for request body schemas.
+
+---
+
+## Conventions
+
+- ESM only. Use `node:` prefix for builtins. No CommonJS interop in
+  generated code.
+- Spec identifier `BookingId` → TS `BookingId` brand; spec field
+  `booking_id` → TS field `bookingId` (lowerCamelCase fields per JS
+  convention).
+- `tsc --noEmit` clean. `eslint .` clean (config emitted with the
+  project; `@typescript-eslint/recommended-type-checked`).
+- No `any`. No non-null assertions outside test setup.
+- Top-level `await` is fine in `index.ts`.
+
+---
+
+## Verification before reporting done
+
+```sh
+cd targets/typescript
+npm install
+npx tsc --noEmit
+npx eslint .
+npm test
+npm run start &
+hurl --variables-file ../../evals/<feature>/fixtures.env \
+     --variable BASE_URL=http://localhost:3000 \
+     ../../evals/<feature>/<feature>.hurl
+```
+
+All five must pass. Don't edit hurl files to make them green.


### PR DESCRIPTION
## Summary

Phase A of the candy alpha plan (`.claude/session-handoff.txt`).

Authors `prompts/codegen-base.md` (universal codegen contract) and
four thin per-target overlays (`codegen-{go,rust,typescript,python}.md`).
Architecture is option (c) from the closed [#36] design discussion:
base + thin overlays + dispatch to existing language-best-practices
skills.

The base specifies the 11-block translation contract, cross-cutting
rules (no floats for money, explicit idempotency keys, one-actor-owns-
state, the M1 \`generate()\`-race trap), refusal conditions, and the
conformance gate against \`evals/<feature>/<feature>.hurl\`.

Each overlay adds:
- Project layout for the target tree.
- Block-by-block bindings to idiomatic target code.
- Library bindings tied to \`preferences.candy\`.
- The verification commands that gate \"done\".

The Go and Rust overlays dispatch to \`golang-best-practices\` and
\`rust-best-practices\`. TypeScript and Python carry more inline idiom
because no equivalent skill exists in this repo's environment yet.

## Files

- \`prompts/README.md\`
- \`prompts/codegen-base.md\` (~500 lines)
- \`prompts/codegen-go.md\` (~300 lines)
- \`prompts/codegen-rust.md\` (~290 lines)
- \`prompts/codegen-typescript.md\` (~280 lines)
- \`prompts/codegen-python.md\` (~270 lines)

## Deviation from session handoff

The handoff suggested overlays would be \"~100 lines\". Actuals are
~270–300 each. The driver is: 11 block types each need a code-shaped
example to anchor the binding, plus framework wiring and verification
commands. Trimming to 100 would force removing the examples; the
examples are where the model gets the most leverage. Surfacing
explicitly per the handoff's \"flag deviations\" rule.

## Test plan

- [ ] Self-review reads as a usable prompt for each target.
- [ ] Cross-references resolve (\`GRAMMAR.md\`, \`evals/README.md\`,
  \`docs/*.md\`, the existing language skills, issues #12, #36).
- [ ] Phase C (auth → Go/chi POC, issue #13) consumes these prompts
  and produces a backend that passes \`evals/auth/auth.hurl\`. That
  validation closes the loop on this PR's correctness.

## Closes

Closes #12.
Refs #13, #14, #15, #16, #36, #39 (parallel phase B).