### PR TITLE
feat(commons): scaffold commons/ with canonical type specs

### DIFF
--- a/commons/README.md
+++ b/commons/README.md
@@ -1,0 +1,108 @@
+# commons/
+
+A repository of canonical candy specs — the same `Email`, `Money`,
+`Hash`, `Token` definitions every project copy-pastes today, written
+once.
+
+This lives in-repo for now as a proof of concept. The intended endgame
+is a separate published project that any candy project can opt into
+via `candy.toml` `[deps]`. Nothing about that endgame is built yet —
+this is the canonical content; the resolver, fetcher, and
+versioning story all come later.
+
+## Layout
+
+```
+commons/
+  README.md                     — this file.
+  types/
+    <TypeName>.candy            — one spec block per file.
+```
+
+One file per type. The filename matches the spec name. Each file
+contains exactly one top-level `spec` block plus its prose.
+
+Currently shipped types:
+
+| File              | Spec      | Underlying primitive | Pinned-by-consumer parameters |
+|-------------------|-----------|-----------------------|--------------------------------|
+| `types/Email.candy`    | `Email`    | `string`  | —          |
+| `types/Money.candy`    | `Money`    | `int`     | `currency` |
+| `types/Hash.candy`     | `Hash`     | `opaque`  | —          |
+| `types/Token.candy`    | `Token`    | `opaque`  | —          |
+| `types/Password.candy` | `Password` | `string`  | —          |
+| `types/Phone.candy`    | `Phone`    | `string`  | —          |
+
+## Status — provisional syntax
+
+The `spec` block, the `use spec` line, and the `refines` extension
+are not yet in `GRAMMAR.md`. This directory is the candidate content
+for those constructs. A grammar ratification PR will land separately;
+when it does, the linter will recognise these blocks and projects
+can adopt them via `use spec Email, Hash, Token` and similar.
+
+Until then, candy CLI (`candy lint`) silently ignores `spec` blocks
+(unknown top-level keyword), so the directory is safe to ship without
+breaking lint.
+
+## Why these and not others
+
+- `Email`, `Hash`, `Token`, `Password`, `Phone` — every shipped
+  example declares them with byte-identical bodies. Unanimous
+  candidates for shared canonical specs.
+- `Money` — every example declares it; `currency` is the only
+  parameter consumers vary, so it ships as a `parameter:` slot.
+- `Id`, `Timestamp` — already built into the language
+  (`GRAMMAR.md` §type "Built-in named types"). They never needed a
+  spec; their canonical shape is the language's.
+- `Key` — deliberately omitted. The idempotency-key parameter is
+  conventionally typed `Key opaque { max: 128 }` (per
+  `GRAMMAR.md` §Hard rules), but the type identifier is
+  project-defined. Projects that want a different name (e.g.
+  `IdempotencyKey`) shouldn't have to fight a commons spec.
+- `Role` — every project's role enum is different (admin/manager/user
+  vs guest/host/admin vs customer/admin). Project-declared, no
+  commons candidate.
+
+## How a project consumes commons (planned)
+
+```candy
+// project's types.candy
+
+use spec Email, Hash, Token, Password, Phone   // unparameterized
+use spec Money(currency: USD)                  // pin the parameter
+
+// shadow when project semantics differ:
+spec Email string refines {
+  intent: """Internal-only — org domain required."""
+  format: company-domain
+}
+```
+
+Resolution rules (proposed):
+
+1. A `spec X` declared in the project wins.
+2. Otherwise, a `use spec X` line resolves against the candy
+   projects listed in `candy.toml` `[deps]`. v0.1 will be local-only;
+   v0.2 ships the fetcher.
+3. Two deps that both export `X` resolve in `[deps]` declaration
+   order.
+
+## Future structure
+
+Follow-ups when the grammar ratification lands:
+
+- `commons/policies/` — shared rule clusters (e.g. `PasswordStrength`
+  is identical across every example with auth).
+- `commons/events/` — canonical events (e.g. `UserSignedUp`,
+  `SessionRevoked`).
+- `commons/externals/` — canonical external actors (`Postmark` for
+  Email, `Polar` for Payments, ...).
+
+Out of scope for this PR. File issues per category.
+
+## Refs
+
+- Discussion in PR #42 / session 2026-05-07.
+- The shape of the `spec` block follows `policy` (`intent:` +
+  `examples:`). See `GRAMMAR.md` §policy.

--- a/commons/types/Email.candy
+++ b/commons/types/Email.candy
@@ -1,0 +1,40 @@
+// Email — RFC 5322 email address.
+//
+// Canonical commons spec. Every project that needs an email address
+// type pulls this in via `use spec Email`. Projects that need
+// different semantics (e.g. internal-domain-only) shadow with
+// `spec Email string refines { ... }` rather than re-declaring the
+// underlying validation.
+
+spec Email string {
+  intent: """
+    An RFC 5322 email address. Length capped at 320 characters per
+    the RFC's local-part (64) plus '@' plus domain (255) limits.
+    Comparison is case-insensitive on the local part — that matches
+    most providers' actual behaviour and avoids surprise on lookup.
+
+    Construction trims surrounding whitespace and rejects malformed
+    input. Storage retains the exact construction-time value;
+    case-insensitive comparison is implemented at the comparison
+    site, not at storage.
+  """
+
+  max:    320
+  format: rfc5322
+  trim:   on-construction
+  compare: case-insensitive
+
+  examples:
+    - given: "alice@example.com"
+      then:  ok
+    - given: "ALICE@Example.COM"
+      then:  ok                    // compares equal to alice@example.com
+    - given: "  bob@example.com  "
+      then:  ok                    // whitespace trimmed at construction
+    - given: "no-at-sign"
+      then:  err(BadEmail)
+    - given: ""
+      then:  err(BadEmail)
+    - given: "a@b"
+      then:  err(BadEmail)         // no TLD on the domain
+}

--- a/commons/types/Hash.candy
+++ b/commons/types/Hash.candy
@@ -1,0 +1,43 @@
+// Hash — one-way hash of a sensitive value.
+//
+// Used wherever the spec writes `hash: PasswordHash` or stores a
+// hashed token / API key. The hash function itself is target-resolved
+// — preferences.candy supplies the concrete library per language
+// (`when need hash use argon2`).
+//
+// Plaintext is never persisted alongside a Hash. Verification uses
+// constant-time comparison.
+
+spec Hash opaque {
+  intent: """
+    A one-way hash of a sensitive value: passwords, secrets, API
+    keys, anything where the plaintext must not be recoverable from
+    storage.
+
+    The hash function is resolved per target via the `when need hash
+    use ...` line in preferences.candy. Argon2id is the recommended
+    default; the spec does not pin it because the choice is a
+    deployment-time decision (FIPS compliance, performance budget,
+    migration cohort).
+
+    Hashed values cross storage boundaries; plaintext does not.
+    Verification is constant-time — `verify(plaintext, hash)` returns
+    true iff `hash(plaintext)` equals the stored hash, with
+    timing-safe comparison.
+
+    A new salt is generated per hash invocation; equal plaintexts
+    produce different stored hashes. Migration to a stronger hash
+    function is a re-hash on next successful authentication, not a
+    background job.
+  """
+
+  verify:    constant-time
+  reversal:  forbidden            // plaintext is not derivable
+
+  examples:
+    - given: "correct horse battery staple 9"
+      then:  ok                   // returns an opaque hash
+    - "verify(plaintext, hash) is true iff plaintext hashes to hash"
+    - "verify uses constant-time comparison (no early return on mismatch)"
+    - "two hash() calls on the same plaintext return different bytes (per-call salt)"
+}

--- a/commons/types/Money.candy
+++ b/commons/types/Money.candy
@@ -1,0 +1,47 @@
+// Money — integer minor units of a pinned currency.
+//
+// Canonical commons spec. Currency is the one parameter projects
+// must pin: `use spec Money(currency: USD)`. Everything else
+// (integer-only, no floats, nearest-half-up rounding) is fixed
+// across all consumers.
+//
+// Per the candy hard rule "no floats for money", consumers must
+// reject float input at construction even when the runtime allows
+// implicit numeric coercion.
+
+spec Money int {
+  intent: """
+    A monetary amount stored as integer minor units of a pinned
+    currency. Currency is fixed at the point of declaration; mixing
+    currencies in arithmetic is a type error, not a runtime one.
+
+    Floats are forbidden at every boundary — input parsing, SDK
+    serialisation, intermediate computation, output rendering. Money
+    arithmetic is exact. Rounding, when required (interest, taxes,
+    proration), follows the round-half-to-nearest convention pinned
+    on the spec.
+
+    The `unit: minor` field means the wire value is in the
+    currency's smallest indivisible unit: cents for USD, pence for
+    GBP, satoshi for BTC. The display layer multiplies by the
+    currency's exponent at render time.
+  """
+
+  unit:     minor
+  currency: parameter            // pinned by `use spec Money(currency: ...)`
+  round:    nearest
+
+  examples:
+    - given: 1500   when: { currency: USD }
+      then:  ok                   // displays as $15.00
+    - given: 0      when: { currency: USD }
+      then:  ok                   // zero is a valid amount
+    - given: -250   when: { currency: USD }
+      then:  ok                   // negatives are valid (refunds, debits)
+    - given: 1500.5
+      then:  err(NotInteger)      // floats forbidden
+    - given: "fifteen"
+      then:  err(NotInteger)
+    - "addition is exact: 1234 + 5678 == 6912 (no rounding step)"
+    - "cross-currency arithmetic is a type error, not a runtime check"
+}

--- a/commons/types/Password.candy
+++ b/commons/types/Password.candy
@@ -1,0 +1,36 @@
+// Password — plaintext credential, transient.
+//
+// Carried only at the boundary between the request body and the
+// hashing step. Never persisted; the only stored derivative is a
+// `Hash` (PasswordHash in conventional projects). The strength
+// policy is project-defined — projects layer their own
+// `policies: [PasswordStrength]` (or stronger) on top of this spec.
+
+spec Password string {
+  intent: """
+    A plaintext password. Transient by construction — present only
+    in the request boundary, the hashing call, and the verify call.
+    Never written to storage, logs, telemetry, audit rows, or error
+    responses.
+
+    The minimum-strength rule (length, character classes, dictionary
+    blocks) is project-policy, not spec-policy. Projects attach a
+    `PasswordStrength` policy at type or actor scope; this spec only
+    pins the no-persist invariant and the no-leak invariant.
+
+    On a successful authentication, projects compare via
+    `verify(password, stored_hash)` from the canonical `Hash` spec.
+    On a successful signup, projects derive `hash(password)` and
+    persist only the hash.
+  """
+
+  persist:   forbidden            // no PlainPassword in any actor's state
+  log:       forbidden            // no plaintext in any log line or error body
+  lifetime:  request-boundary     // exists from request parse to hash call
+
+  examples:
+    - "Signup body carries a Password; signup flow hashes it; only the hash is persisted"
+    - "Login compares the supplied Password against the persisted hash via verify()"
+    - "an `actor User` declaring `state { password: Password }` violates the persist rule"
+    - "an error response saying `weak_password: \"<plaintext>\"` violates the log rule"
+}

--- a/commons/types/Phone.candy
+++ b/commons/types/Phone.candy
@@ -1,0 +1,42 @@
+// Phone — E.164 phone number.
+//
+// Used by the notifications feature for SMS routing. E.164 is the
+// only format candy projects accept; locale-specific shapes
+// ("(415) 555-1234") are normalised to E.164 at construction or
+// rejected.
+
+spec Phone string {
+  intent: """
+    An E.164 phone number. The format is a leading '+', a country
+    code (1–3 digits), and a national subscriber number, with no
+    separators — total length 16 or fewer characters.
+
+    Locale-specific shapes (parentheses, hyphens, spaces, leading
+    zeros for trunk codes) are normalised to E.164 at construction
+    or rejected. Projects that need to display a locale-specific
+    rendering format from the stored E.164 at render time, not in
+    the type itself.
+
+    Comparison is exact-byte (no normalisation needed at compare
+    time, since construction normalised). Storage is the
+    normalised form.
+  """
+
+  max:    16
+  format: e164
+  trim:   on-construction
+
+  examples:
+    - given: "+14155550123"
+      then:  ok
+    - given: "+442071838750"
+      then:  ok                   // UK landline
+    - given: "(415) 555-0123"
+      then:  ok                   // normalised at construction to +14155550123
+    - given: "415-555-0123"
+      then:  err(BadPhone)        // missing country code; cannot infer
+    - given: "+1 415 555 0123"
+      then:  ok                   // whitespace stripped, normalised
+    - given: ""
+      then:  err(BadPhone)
+}

--- a/commons/types/Token.candy
+++ b/commons/types/Token.candy
@@ -1,0 +1,35 @@
+// Token — opaque bearer token.
+//
+// Issued by an auth flow on successful login; carried in
+// `Authorization: Bearer <token>` headers; revoked by writing a
+// SessionRevoked event. Length cap bounds header size.
+
+spec Token opaque {
+  intent: """
+    An opaque bearer token. Carried in Authorization: Bearer headers
+    and never logged. Length capped at 256 characters to bound
+    request-header size and avoid header-size attacks against
+    upstream proxies.
+
+    Tokens are produced by an auth flow (typically signing a JWT or
+    issuing a random opaque string) and consumed by route middleware
+    that validates them before dispatching the handler. The exact
+    encoding (JWT, paseto, opaque random) is target-resolved via
+    preferences.candy `when need jwt use ...` (or equivalent for
+    non-JWT runtimes).
+
+    Comparison is constant-time. Tokens never appear in logs, error
+    messages, audit trails, or telemetry — observability surfaces
+    record only the authenticated principal id, not the bearer that
+    yielded it.
+  """
+
+  max:     256
+  compare: constant-time
+  log:     forbidden
+
+  examples:
+    - "tokens are issued by Login / Signup flows on success"
+    - "tokens are consumed by `auth: bearer` controller middleware"
+    - "the raw token never appears in a log line, error response, or audit row"
+}


### PR DESCRIPTION
## Summary

Establishes the in-repo candy commons discussed in PR #42's review
thread. Six canonical type specs that today every example
re-declares with byte-identical bodies, written once.

## Layout

\`\`\`
commons/
  README.md
  types/
    Email.candy        — RFC 5322 email; max 320; case-insensitive compare
    Money.candy        — integer minor units; pinned currency parameter
    Hash.candy         — one-way hash; constant-time verify; argon2 default
    Token.candy        — opaque bearer; max 256; never logged
    Password.candy     — transient plaintext; never persisted
    Phone.candy        — E.164 normalised at construction
\`\`\`

One file per type. Each contains exactly one \`spec\` block with the
\`policy\`-style prose (\`intent:\` + meta fields + \`examples:\`).

## Status — provisional syntax

The \`spec\` block, the \`use spec\` line, and the \`refines\` extension
are **not yet** in \`GRAMMAR.md\`. A grammar ratification PR follows
separately; once it lands the linter will recognise these blocks and
projects can adopt them via \`use spec Email, Hash, Token\` (and pin
parameters via \`use spec Money(currency: USD)\`).

Until ratification, \`candy lint\` silently ignores \`spec\` blocks
(unknown top-level keyword falls through the parser's recovery
path). \`candy lint commons/\` exits 0; nothing about this PR breaks
lint or CI.

## Deliberate omissions

- **\`Key\`** — per session feedback, the idempotency-key parameter
  type is project-defined. Projects that prefer \`IdempotencyKey\`
  shouldn't have to fight a commons spec named \`Key\`.
- **\`Role\`** — every project's roles differ (admin/manager/user vs
  guest/host/admin vs customer/admin). No commons candidate.
- **\`Id\`, \`Timestamp\`** — already language built-ins
  (\`GRAMMAR.md\` §type \"Built-in named types\"). They never needed a
  spec.

## Future structure

When the grammar ratification PR lands, follow-ups for
\`commons/policies/\`, \`commons/events/\`, \`commons/externals/\` open up.
Out of scope here.

## Test plan

- [x] \`candy lint commons/\` exits 0 (linter ignores \`spec\` as
  unknown keyword).
- [x] \`candy lint examples/\` continues to exit 0 (unchanged).
- [ ] Once the grammar ratification PR lands, the linter parses
  \`spec\` blocks and \`candy lint commons/\` reports zero violations
  in this corpus.
- [ ] One example migrates to \`use spec Email, Hash, Token, ...\`
  as the proof-point for the resolution mechanic. Separate PR.

## Refs

- #42 (built-in type set discussion).
- #41 (codegen prompts; merged).
- Session log 2026-05-07.