### PR TITLE
docs(grammar): ratify spec block, use spec, refines

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -20,9 +20,9 @@ words in each, and you can read any candy file.
 
 ```
 ENTITY      things that exist
-            actor  external  state  config  providers  enum  type
+            actor  external  state  config  providers  enum  type  spec
             derive  journal  audit  self  id
-            flow  controller  event  policy  target  prose
+            flow  controller  event  policy  target  prose  refines
 
 ACTION      things that happen
             ask  tell  emit  emits  effect  commit  compensate  reject
@@ -38,9 +38,11 @@ INTENT      why this exists, what good looks like
             intent  examples  because
 ```
 
-`flow`, `controller`, `event`, `policy` are block-defining ENTITY keywords —
-they declare a thing in the system. `policy` is also an INTENT primitive (it
-holds the why) but lives once in the table under ENTITY.
+`flow`, `controller`, `event`, `policy`, `spec` are block-defining ENTITY
+keywords — they declare a thing in the system. `policy` is also an INTENT
+primitive (it holds the why) but lives once in the table under ENTITY.
+`refines` is an ENTITY modifier — it attaches to a `spec` block to extend or
+override an imported spec.
 
 ---
 
@@ -76,6 +78,7 @@ holds the why) but lives once in the table under ENTITY.
 | `event`           | A typed message broadcast to subscribers.                |
 | `type`            | A record, or a branded primitive with pinned semantics.  |
 | `enum`            | A sum (variant) type.                                    |
+| `spec`            | A reusable type contract — shape, constraints, prose, examples. Compiles to a `type`. |
 | `invariant`       | A truth that must hold (actor-local or system-wide).     |
 | `prose`           | Feature interface — intent, exports, uses, policies.     |
 | `target`          | Per-target library and idiom preferences (preferences.candy). |
@@ -553,6 +556,136 @@ Type composition:
 - `Result<Ok, Err>` — success or failure (where `Err` is one variant or a
   union `A | B | C`).
 - `unit` — built-in unit type (no value).
+
+---
+
+## spec
+
+A `spec` block is a reusable type contract: an underlying primitive plus
+constraints, prose, and examples. It compiles to a `type` — semantics are
+identical, the difference is verbosity and reuse.
+
+Use `spec` when the same shape repeats across projects (`Email`, `Money`,
+`Hash`, `Token`) and you want one canonical definition. Use `type` when
+the shape is project-local.
+
+```candy
+spec Email string {
+  intent: """
+    An RFC 5322 email address. Length capped at 320 characters.
+    Comparison is case-insensitive on the local part.
+  """
+
+  max:    320
+  format: rfc5322
+  trim:   on-construction
+
+  examples:
+    - given: "alice@example.com"
+      then:  ok
+    - given: "no-at-sign"
+      then:  err(BadEmail)
+}
+```
+
+A `spec` block has:
+
+- **A name** — `Email` here. Becomes the type name when the spec is
+  consumed.
+- **An underlying primitive** — `string` here. Same fixed set as `type`:
+  `int`, `string`, `opaque`, `bool`, `bytes`, `instant`, `decimal`.
+- **`intent:`** — prose describing what the type means and why.
+- **Meta-fields** — `max`, `format`, `currency`, `unit`, `round`, `tz`,
+  ... — the same set `type` block bodies use, plus any spec-specific
+  fields the spec author needs (`trim`, `compare`, `verify`, ...).
+- **`examples:`** — first-class examples in the same shape `policy`
+  uses: `given:` / `then: ok` or `then: err(...)`. Examples are
+  conformance: generated tests must pass each.
+
+### Required parameters
+
+A spec can mark a meta-field as a parameter the consumer must pin:
+
+```candy
+spec Money int {
+  intent: """Integer minor units of a pinned currency."""
+
+  unit:     minor
+  currency: parameter           // consumer fills this in
+  round:    nearest
+}
+```
+
+`parameter` is a reserved value meaning "the consumer must provide this
+when applying the spec." A spec with unfilled parameters cannot itself
+be used as a type — only its parameterized application is a valid type.
+
+### Applying a spec — `use spec`
+
+A consumer brings one or more specs into scope with `use spec`. The
+line is top-level in a `.candy` file:
+
+```candy
+use spec Email, Hash, Token                 // unparameterized
+use spec Money(currency: USD)               // pin the parameter
+```
+
+After `use spec X`, `X` is a type identifier in the file's scope. It
+behaves identically to a project-local `type X primitive { ... }`.
+
+Resolution order:
+
+1. A `spec X` block declared somewhere in the same project wins
+   (project-local always shadows imported).
+2. Otherwise, the toolchain consults `candy.toml` `[deps]` and
+   resolves `X` against the candy projects listed there.
+3. If two deps both export `X`, declaration order in `[deps]` wins.
+4. If no resolution, generation fails with a clear error.
+
+The dep-fetch resolver is future tooling; v0.1 is local-only (deps
+checked into the project tree, or a sibling repo on the local
+filesystem).
+
+### Refining a spec — `refines`
+
+A consumer can extend or override a brought-in spec:
+
+```candy
+use spec Email
+
+spec Email string refines {
+  intent: """Internal-only — org domain required."""
+  format: company-domain
+}
+```
+
+`refines` takes the brought-in spec's body, applies the listed
+overrides, and produces a project-local type that shadows the imported
+one in the rest of the file. Meta-fields not mentioned in `refines`
+carry over from the original.
+
+A `refines` block must include the same underlying primitive as the
+spec it refines. Changing the primitive is a type identity change, not
+a refinement — declare a fresh `spec` instead.
+
+### Compilation contract
+
+For codegen, a `spec` block compiles **identically** to a `type` block
+with the same shape. Codegen reads:
+
+- A direct `spec X primitive { ... }` declaration → emits the same
+  target code it would emit for `type X primitive { ... }`.
+- A `use spec X` line → resolves `X` per the rules above, then emits
+  target code as if the resolved spec body had been written inline as
+  a `type` block in this file.
+- A `spec X primitive refines { ... }` → resolves the original,
+  applies the overrides, emits as if the merged shape had been written
+  inline.
+
+Target overlays do not need spec-awareness — the spec → type
+translation happens before the target overlay runs. The
+`examples:` on each spec produce unit tests in the generated tree the
+same way `policy` examples do.
 
 ---
 

--- a/prompts/codegen-base.md
+++ b/prompts/codegen-base.md
@@ -246,6 +246,32 @@ the mismatch. Don't downgrade silently.
 Identity types (`type Id ...`): generate an opaque wrapper so an `UserId`
 cannot be passed where a `BookingId` is expected.
 
+### `spec`
+
+A `spec` block is a `type` with prose, examples, and reuse semantics
+(GRAMMAR.md "spec"). Compile it identically to its underlying `type`:
+
+| Spec construct                              | Emission contract                                 |
+|---------------------------------------------|---------------------------------------------------|
+| `spec X primitive { ... }`                  | Emit as if `type X primitive { ... body ... }`.   |
+| `examples:` cases on the spec               | Generate unit tests asserting each `given`/`then` mapping (same as `policy`). |
+| `currency: parameter` (or any `parameter` value) | This spec is unparameterized; refuse to use it as a type without an applied parameterization. |
+| `use spec X`                                | Resolve `X` (project-local first; then `[deps]`); emit as if the resolved spec body had been written inline as a `type` block in this file. |
+| `use spec X(field: value, ...)`             | Apply the parameter substitution to the resolved spec, then emit as for `use spec X`. |
+| `spec X primitive refines { ... }`          | Resolve the original `X`, apply the listed overrides, emit as if the merged shape had been written inline as a `type X` declaration. |
+
+Resolution rules for `use spec X`:
+
+1. Project-local `spec X` declaration wins.
+2. Otherwise, look up `X` in projects listed in `candy.toml` `[deps]`,
+   in declaration order.
+3. If unresolved, refuse and report `unresolved use spec X` with the
+   file and line.
+
+A spec cannot be used as a type until every `parameter` field is
+filled — either by `use spec X(field: value)` at the consumption site,
+or by `refines` substituting a value. Generation fails otherwise.
+
 ### `invariant`
 
 | Form                              | Emission contract                                 |


### PR DESCRIPTION
## Summary

Ratifies the language constructs discussed in PR #42's review thread
and proven out by the canonical types in PR #43.

The grammar gains three things:

1. **\`spec\` block** — a \`type\` with prose, examples, and reuse
   semantics. Reads like \`policy\` (\`intent:\` + \`examples:\`);
   produces a type. Same fixed set of underlying primitives.
2. **\`use spec X, Y, Z\`** — top-level line that brings one or more
   specs into a file's scope. Supports parameterization via
   \`use spec Money(currency: USD)\`.
3. **\`spec X primitive refines { ... }\`** — extend or override an
   imported spec; meta-fields not mentioned carry over.

## What changed

- **\`GRAMMAR.md\`**:
  - \`spec\` added to the ENTITY word-axis; \`refines\` added as an
    ENTITY modifier.
  - \`spec\` added to the \"Block types at a glance\" table.
  - New §\`spec\` section covering the block shape, required
    parameters, \`use spec\` resolution rules, \`refines\` semantics,
    and the compilation contract.
- **\`prompts/codegen-base.md\`**:
  - New §\`spec\` row in the type/enum mapping table.
  - Codegen rules: \`spec\`, \`use spec\`, \`refines\` all compile
    identically to a \`type\` block before target overlays run.
  - Examples on a spec produce unit tests the same way \`policy\`
    examples do.
  - Unresolved \`use spec\` is a refusal condition.

## Resolution rules (locked)

For \`use spec X\`:

1. Project-local \`spec X\` declaration wins.
2. Otherwise, \`candy.toml\` \`[deps]\` projects, in declaration order.
3. Unresolved → refuse generation with a clear error.

The dep-fetch resolver is future tooling — v0.1 is local-only.

## What this enables

- The six canonical specs in PR #43's \`commons/types/\` become
  consumable via \`use spec Email, Hash, Token, Password, Phone\` and
  \`use spec Money(currency: USD)\`.
- Examples can drop the ~30 lines of copy-pasted type declarations
  each currently carries (separate migration PR — see #43's
  \"Future structure\").

## Out of scope

- **Linter spec recognition.** Today the linter (PR #42, in flight)
  ignores \`spec\` and \`use spec\` as unknown top-level keywords; this
  PR doesn't change that. Once #42 merges, a follow-up PR teaches
  the parser to recognise \`spec\`/\`use spec\`/\`refines\` and adds two
  new lint rules: \`spec-required-intent\` and
  \`unresolved-use-spec\`.
- **Dep fetcher.** v0.1 ships local-only resolution. Cross-project
  \`use spec\` works when the dep is on the local filesystem but
  \`candy install\` doesn't exist yet.
- **Migration of examples.** No example file changes here. Once both
  this PR and #43 merge, a separate PR migrates each example to
  \`use spec ...\`.

## Test plan

- [ ] Self-review: the grammar reads cleanly; the codegen prompt
  changes are internally consistent with the rest of base.md.
- [ ] After merge: \`candy lint commons/\` (PR #43) still exits 0.
- [ ] After merge + #42 merge: follow-up PR adds linter recognition
  and migrates one example as proof-point.

## Refs

- #42 (built-in type set discussion → spec design).
- #43 (\`commons/\` proof of concept).
- #41 (codegen prompts; merged).