### PR TITLE
docs: add NEXT.md and CLAUDE.md for next-session bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — candy
+
+Project-level context Claude Code loads on every session in this repo.
+
+## Read first, in order
+
+1. **`NEXT.md`** — the menu of next-step targets. Always check this first when starting a session in this repo; it tells you what to work on and what's locked.
+2. **`.claude/session-handoff.txt`** — the running handoff between sessions. Active phase status, locked decisions, open items.
+3. **`README.md`** — project overview.
+4. **`GRAMMAR.md`** — the candy language reference.
+5. **`evals/README.md`** — the conformance contract (hurl is the cross-target reference for now; per-target native suites planned — see `docs/testing-strategy.md`).
+
+## Key directories
+
+| Path                                  | Purpose                                                                                                                                   |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `prompts/`                            | Codegen prompts (base + 4 target overlays).                                                                                               |
+| `examples/<feature>/`                 | Canonical example specs.                                                                                                                  |
+| `examples/<feature>/targets/<lang>/`  | Generated backends. Do not hand-edit; regenerate from spec.                                                                               |
+| `commons/types/`                      | Canonical type specs (Email, Hash, Money, Token, Password, Phone). Provisional `spec` syntax pending linter integration.                  |
+| `evals/<feature>/`                    | hurl scenarios + fixtures + .md narratives.                                                                                               |
+| `cli/`                                | Rust `candy` CLI (currently: `candy lint`).                                                                                               |
+| `docs/`                               | Architecture, externals, features, candy.toml schema, cli-modes (green/brown), testing-strategy.                                         |
+| `.retrospective/`                     | Per-phase retrospectives.                                                                                                                 |
+
+## Standing rules — surface deviations
+
+- **Honour `preferences.candy` exactly.** Sub-agents have repeatedly tried to substitute a "simpler" implementation (KSUID-in-DB instead of JWT) when the spec/preferences pin a specific library. Don't.
+- **Don't modify the spec or fixture to make a test pass.** When the eval fails, find the wrong side. Usually the fixture is wrong; sometimes the spec is ambiguous and needs ratification. Surface the conflict, don't silence it.
+- **Atomic commits per logical change.** No `git add -A`.
+- **No AI co-author footer.** The project disables it.
+- **Generated source files start with the codegen header.** "Generated from spec/<path> — do not edit; regenerate from spec." Humans regenerate; they don't edit `targets/<lang>/`.
+
+## When in doubt
+
+- Spec ambiguity: read GRAMMAR.md and the relevant example's `.candy` files; flag in HANDOFF if still unclear.
+- Locked decision conflict: `.claude/session-handoff.txt` §7 lists what's locked. Don't relitigate without strong reason.
+- New phase: write a HANDOFF.md inside the generated tree as the running judgment-call log.
+- Stuck after two attempts: stop and surface to the user. Don't loop.

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,0 +1,48 @@
+# NEXT — post-alpha workstream
+
+Alpha shipped 2026-05-08: 4 backends green (auth/Go, auth/Rust, todo/Go, wallet/Go), 99 hurl scenarios passing, codegen prompts + linter + commons/ + spec grammar all merged. See `.retrospective/phase-alpha-codegen.md` for the full debrief.
+
+This file is the menu of what comes next, ordered by adoption-blocking leverage. Each item links to its tracking doc.
+
+## Targets, ordered by priority
+
+1. **Phase F — harder examples (billing, notifications, airbnb).** Each surfaces grammar / preferences / external-actor edges the simple examples didn't. Billing has 3 schedules + Polar canonical. Notifications has multi-provider rescue chains + Postmark. Airbnb has the multi-actor saga with compensation. **Highest signal for "is the spec ready for a real project."** Recommended starting point: billing (smallest of the three; reuses the schedule machinery proven on wallet).
+
+2. **TS + Python auth targets.** Closes the four-target conformance story. Validates the codegen prompts on the two languages without a `*-best-practices` skill (where prompt quality was a documented unknown — see prompts/codegen-typescript.md and prompts/codegen-python.md headers).
+
+3. **`candy test` subcommand (Phase G).** Consolidates the hurl runner into the Rust CLI. Sets up per-target CI workflows. Cheaper than Phase F and unlocks regression-catching infrastructure.
+
+4. **Linter learns `spec` syntax + migrate one example to `use spec ...`.** Closes the loop from the spec-grammar PR (#44) and commons/ PR (#43): teach `candy lint` to parse `spec` / `use spec` / `refines`, add two new lint rules (`spec-required-intent`, `unresolved-use-spec`), then migrate one example (auth is smallest) to `use spec Email, Hash, Token, Password` as the proof of commons consumption.
+
+5. **Tier-1 integration test emission.** Per `docs/testing-strategy.md`: generate target-native test suites (Go testing + httptest, Rust #[tokio::test] + axum-test, vitest + hono.fetch, pytest + httpx) alongside the backend code. Each hurl scenario transliterates mechanically. Hurl stays as the cross-target reference.
+
+6. **Brown mode B3 adapter prototype.** Per `docs/cli-modes.md`: take a small existing Go project, generate just the controller layer as adapters around existing service code. Measure the diff. The "spec change → small code diff" metric is the test for whether brownfield is viable.
+
+7. **Codegen-time spec/preferences checker.** Per `.retrospective/phase-alpha-codegen.md` §6 forward risks: a mechanical linter rule that catches when generated code drifts from `preferences.candy` (e.g. `when need jwt use golang-jwt` declared but no jsonwebtoken-equivalent imported). Cheaper than orchestrator review-and-rewrite.
+
+## Parallelisable
+
+Items 1 + 2 are non-blocking — different examples / different targets / different files. A Phase F sub-agent for billing-on-Go and a TS-auth sub-agent can run concurrently.
+
+Items 3, 4, 7 each depend only on the merged main; can run sequentially or in parallel.
+
+Items 5 and 6 are larger explorations; each deserves its own session and likely a discuss-phase before any code lands.
+
+## What is locked
+
+Don't relitigate without strong reason. See `.claude/session-handoff.txt` §7 "Decisions → Locked":
+
+- Sessions are JWTs, not KSUID-in-DB (auth.candy prose pins this; revocation via small `revoked_jtis` table; two middlewares for bearer-strict vs bearer-permissive).
+- Money is integer minor units; no floats anywhere money flows.
+- `Id` and `Timestamp` are language-built-in named types; everything else (Money, Email, Password, Token, Key, Role) is project-declared (per GRAMMAR.md §type "Built-in named types").
+- `subscribe` block form is ratified.
+- `spec` / `use spec` / `refines` are ratified (PR #44).
+- Hurl is the cross-target reference, not the long-term test surface (per `docs/testing-strategy.md`).
+
+## When you start
+
+1. Read `.claude/session-handoff.txt` for project-level state.
+2. Read this file (NEXT.md) for the menu.
+3. Read `.retrospective/phase-alpha-codegen.md` for what worked, what didn't, and forward risks.
+4. Pick a target from §"Targets" above.
+5. Discuss with the user before spawning a multi-hour codegen sub-agent — confirm the pick.


### PR DESCRIPTION
## Summary

Two short root-level docs that close out this post-alpha session and
bootstrap the next one cleanly.

- **\`NEXT.md\`** — the menu of seven prioritised next-step targets
  (Phase F harder examples, TS+Python auth, \`candy test\`
  subcommand, linter-learns-spec, tier-1 integration tests, brown
  mode prototype, codegen-time preferences checker). Ordered by
  adoption-blocking leverage. Includes a "what is locked" section
  so the next session doesn't relitigate decisions.

- **\`CLAUDE.md\`** — project-level Claude Code context. Tells the
  next session to read NEXT.md first, then session-handoff, then
  README/GRAMMAR/evals. Lists the standing rules that came out of
  the alpha retrospective (honour preferences.candy, don't silence
  spec/fixture conflicts, atomic commits, no AI co-author footer,
  codegen-header on generated files).

Together they're the first-read surface for any new session in this
repo.

## What's in NEXT.md

Seven items, ordered:

1. Phase F — harder examples (billing → notifications → airbnb).
   Highest signal for "is the spec ready for a real project."
2. TS + Python auth targets — closes the four-target story.
3. \`candy test\` subcommand — consolidates hurl runner, sets up
   per-target CI.
4. Linter learns \`spec\` syntax + migrate one example to
   \`use spec ...\` — closes the loop from PR #43/#44.
5. Tier-1 integration test emission per
   \`docs/testing-strategy.md\`.
6. Brown mode B3 adapter prototype per \`docs/cli-modes.md\`.
7. Codegen-time spec/preferences checker per the alpha retro's
   forward risks.

Plus parallelisation hints (1+2 are non-blocking; 3+4+7 each
sequential or parallel; 5+6 deserve their own session with a
discuss-phase first).

## What's in CLAUDE.md

- Read-first ordering.
- Key directory table.
- Standing rules surfaced from \`.retrospective/phase-alpha-codegen.md\`.
- "When in doubt" pointers (spec ambiguity, locked-decision
  conflicts, new phase, two-attempt timeout).

## Out of scope

No code. No spec changes. No generated-code touches.

## Closes / Refs

- Closes the post-alpha session — workstream pauses here.
- Refs \`docs/cli-modes.md\` (#51 merged), \`docs/testing-strategy.md\`
  (#52 merged), \`.retrospective/phase-alpha-codegen.md\` (#50
  merged).